### PR TITLE
Remove exit 1 from integrate/promote commands

### DIFF
--- a/bin/git-integrate
+++ b/bin/git-integrate
@@ -10,7 +10,6 @@ include Socialcast::Git
 
 branch = current_branch
 protect_reserved_branches!(branch, 'integrate')
-exit 1
 
 run_cmd 'git update'
 integrate(branch, 'prototype')

--- a/bin/git-promote
+++ b/bin/git-promote
@@ -7,8 +7,6 @@ include Socialcast::Git
 branch = current_branch
 protect_reserved_branches!(branch, 'promote')
 
-exit 1
-
 run_cmd 'git update'
 integrate(branch, 'staging')
 


### PR DESCRIPTION
Integrate/Promote have an `exit 1` cmd in the middle of the method (likely from refactoring the reserved branch guard into a method).  
