### PR TITLE
fix git reviewrequest to work with https github urls

### DIFF
--- a/bin/git-reviewrequest
+++ b/bin/git-reviewrequest
@@ -1,2 +1,4 @@
+#!/usr/bin/env ruby
+
 require File.join(File.dirname(__FILE__), '..', 'lib', 'socialcast-git-extensions', 'cli.rb')
 Socialcast::Gitx::CLI.start (['reviewrequest'] + ARGV)


### PR DESCRIPTION
git reviewrequest doesn't work with https URLs like https://github.com/socialcast/socialcast-git-extensions.git
