### PR TITLE
prune-config-settings

### DIFF
--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -101,7 +101,7 @@ module Socialcast
         run_cmd "git checkout #{Socialcast::Gitx::BASE_BRANCH}"
         run_cmd 'git pull'
         run_cmd "git checkout -b #{branch_name}"
-
+   
         post "#worklog starting work on #{branch_name} #scgitx"
       end
 
@@ -151,6 +151,7 @@ module Socialcast
       end
 
       desc 'release', 'release the current branch to production'
+      method_option :prune, :type => :boolean, :force => true, :aliases => '-p'
       def release
         branch = current_branch
         assert_not_protected_branch!(branch, 'release')
@@ -162,8 +163,9 @@ module Socialcast
         run_cmd "git pull origin #{Socialcast::Gitx::BASE_BRANCH}"
         run_cmd "git pull . #{branch}"
         run_cmd "git push origin HEAD"
-        integrate_branch('master', 'staging')
-        cleanup
+        integrate_branch('master', 'staging')      
+        #prune when setting is absent from YML, -p or --prune overrides YML
+        cleanup if should_prune? && options[:prune]
 
         post "#worklog releasing #{branch} to production #scgitx"
       end

--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -101,7 +101,7 @@ module Socialcast
         run_cmd "git checkout #{Socialcast::Gitx::BASE_BRANCH}"
         run_cmd 'git pull'
         run_cmd "git checkout -b #{branch_name}"
-   
+
         post "#worklog starting work on #{branch_name} #scgitx"
       end
 

--- a/lib/socialcast-git-extensions/git.rb
+++ b/lib/socialcast-git-extensions/git.rb
@@ -169,6 +169,12 @@ module Socialcast
       def review_buddies
         config['review_buddies'] || {}
       end
+      
+      # load prune setting from SCGITX Configuration YML
+      def should_prune?
+         config['should_prune'] || true
+      end
+      
     end
   end
 end


### PR DESCRIPTION
- WORK IN PROGRESS.
- continue default behavior of pruning merged branches on release
- respect new should_prune setting if it exists in YML file
- override should_prune setting in YML file via --no-prune 
  or --prune flag on release.

Questions: Does ```method_option :prune, :type => :boolean, :force => true, :aliases => '-p'``` make the prune option default to true if not provided?

- Should I call the param something else instead of should_prune? 
- No idea how I should write tests for this. Suggestions?
- is my logic correct?