### PR TITLE
allow-non-master-base-branch

### DIFF
--- a/config/scgitx.yml
+++ b/config/scgitx.yml
@@ -4,5 +4,7 @@ review_buddies:
     socialcast_username: VanMiranda
     buddy: wireframe
   wireframe:
-    socialcast_username: RyanSonnek 
+    socialcast_username: RyanSonnek
     buddy: vanm
+
+base_branch: master

--- a/lib/socialcast-git-extensions.rb
+++ b/lib/socialcast-git-extensions.rb
@@ -6,7 +6,7 @@ require 'socialcast-git-extensions/github'
 
 module Socialcast
   module Gitx
-    BASE_BRANCH = 'master'
+    DEFAULT_BASE_BRANCH = 'master'
 
     private
     # execute a shell command and raise an error if non-zero exit code is returned

--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -56,21 +56,21 @@ module Socialcast
         say 'updating '
         say "#{branch} ", :green
         say "to have most recent changes from "
-        say Socialcast::Gitx::BASE_BRANCH, :green
+        say base_branch, :green
 
         run_cmd "git pull origin #{branch}" rescue nil
-        run_cmd "git pull origin #{Socialcast::Gitx::BASE_BRANCH}"
+        run_cmd "git pull origin #{base_branch}"
         run_cmd 'git push origin HEAD'
       end
 
       desc 'cleanup', 'Cleanup branches that have been merged into master from the repo'
       def cleanup
-        run_cmd "git checkout #{Socialcast::Gitx::BASE_BRANCH}"
+        run_cmd "git checkout #{base_branch}"
         run_cmd "git pull"
         run_cmd 'git remote prune origin'
 
         say "Deleting branches that have been merged into "
-        say Socialcast::Gitx::BASE_BRANCH, :green
+        say base_branch, :green
         branches(:merged => true, :remote => true).each do |branch|
           run_cmd "git push origin --delete #{branch}" unless aggregate_branch?(branch)
         end
@@ -98,7 +98,7 @@ module Socialcast
           end
         end
 
-        run_cmd "git checkout #{Socialcast::Gitx::BASE_BRANCH}"
+        run_cmd "git checkout #{base_branch}"
         run_cmd 'git pull'
         run_cmd "git checkout -b #{branch_name}"
 
@@ -158,14 +158,14 @@ module Socialcast
         return unless yes?("Release #{branch} to production? (y/n)", :green)
 
         update
-        run_cmd "git checkout #{Socialcast::Gitx::BASE_BRANCH}"
-        run_cmd "git pull origin #{Socialcast::Gitx::BASE_BRANCH}"
+        run_cmd "git checkout #{base_branch}"
+        run_cmd "git pull origin #{base_branch}"
         run_cmd "git pull . #{branch}"
         run_cmd "git push origin HEAD"
-        integrate_branch('master', 'staging')
+        integrate_branch(base_branch, 'staging')
         cleanup
 
-        post "#worklog releasing #{branch} to production #scgitx"
+        post "#worklog releasing #{branch} to #{base_branch} #scgitx"
       end
 
       private

--- a/lib/socialcast-git-extensions/git.rb
+++ b/lib/socialcast-git-extensions/git.rb
@@ -57,14 +57,14 @@ module Socialcast
         say "branch to "
         say head_branch, :green
 
-        run_cmd "git checkout #{Socialcast::Gitx::BASE_BRANCH}"
+        run_cmd "git checkout #{base_branch}"
         refresh_branch_from_remote head_branch
         removed_branches = branches(:remote => true, :merged => "origin/#{branch}") - branches(:remote => true, :merged => "origin/#{head_branch}")
         run_cmd "git branch -D #{branch}" rescue nil
         run_cmd "git push origin --delete #{branch}" rescue nil
         run_cmd "git checkout -b #{branch}"
         share_branch branch
-        run_cmd "git checkout #{Socialcast::Gitx::BASE_BRANCH}"
+        run_cmd "git checkout #{base_branch}"
 
         removed_branches
       end
@@ -83,7 +83,7 @@ module Socialcast
       # blow away the local aggregate branch to ensure pulling into most recent "clean" branch
       def integrate_branch(branch, destination_branch)
         assert_not_protected_branch!(branch, 'integrate') unless aggregate_branch?(destination_branch)
-        raise "Only aggregate branches are allowed for integration: #{AGGREGATE_BRANCHES}" unless aggregate_branch?(destination_branch) || destination_branch == Socialcast::Gitx::BASE_BRANCH
+        raise "Only aggregate branches are allowed for integration: #{AGGREGATE_BRANCHES}" unless aggregate_branch?(destination_branch) || destination_branch == base_branch
         say "Integrating "
         say "#{branch} ", :green
         say "into "
@@ -108,7 +108,7 @@ module Socialcast
 
       # build a summary of changes
       def changelog_summary(branch)
-        changes = `git diff --stat origin/#{Socialcast::Gitx::BASE_BRANCH}...#{branch}`.split("\n")
+        changes = `git diff --stat origin/#{base_branch}...#{branch}`.split("\n")
         stats = changes.pop
         if changes.length > 5
           dirs = changes.map do |file_change|
@@ -157,7 +157,7 @@ module Socialcast
           end
         end
       end
-      
+
       # @returns a [Pathname] for the scgitx.yml Config File
       # from either ENV['SCGITX_CONFIG_PATH'] or default $PWD/config/scgitx.yml
       def config_file
@@ -168,6 +168,10 @@ module Socialcast
       # @returns [Hash] of review buddy mapping from Config YML (ex: {'wireframe' => {'socialcast_username' => 'RyanSonnek', 'buddy' => 'vanm'}})
       def review_buddies
         config['review_buddies'] || {}
+      end
+
+      def base_branch
+        config['base_branch'] || Socialcast::Gitx::DEFAULT_BASE_BRANCH
       end
     end
   end

--- a/lib/socialcast-git-extensions/github.rb
+++ b/lib/socialcast-git-extensions/github.rb
@@ -33,11 +33,11 @@ module Socialcast
       # returns the url of the created pull request
       # @see http://developer.github.com/v3/pulls/
       def create_pull_request(token, branch, repo, body)
-        payload = {:title => branch, :base => Socialcast::Gitx::BASE_BRANCH, :head => branch, :body => body}.to_json
+        payload = {:title => branch, :base => base_branch, :head => branch, :body => body}.to_json
         say "Creating pull request for "
         say "#{branch} ", :green
         say "against "
-        say "#{Socialcast::Gitx::BASE_BRANCH} ", :green
+        say "#{base_branch} ", :green
         say "in "
         say repo, :green
         response = RestClient::Request.new(:url => "https://api.github.com/repos/#{repo}/pulls", :method => "POST", :payload => payload, :headers => {:accept => :json, :content_type => :json, 'Authorization' => "token #{token}"}).execute
@@ -53,12 +53,12 @@ module Socialcast
         data = JSON.parse e.http_body
         say "Failed to create pull request: #{data['message']}", :red
       end
-      
+
       # @returns [String] socialcast username to assign the review to
       # @returns [nil] when no buddy system configured or user not found
       def socialcast_review_buddy(current_user)
         review_requestor = review_buddies[current_user]
-        
+
         if review_requestor && review_buddies[review_requestor['buddy']]
           review_buddies[review_requestor['buddy']]['socialcast_username']
         end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -126,7 +126,7 @@ describe Socialcast::Gitx::CLI do
     end
     context 'when user confirms release' do
       before do
-        Socialcast::Gitx::CLI.any_instance.should_receive(:post).with("#worklog releasing FOO to production #scgitx")
+        Socialcast::Gitx::CLI.any_instance.should_receive(:post).with("#worklog releasing FOO to master #scgitx")
         Socialcast::Gitx::CLI.any_instance.should_receive(:yes?).and_return(true)
         Socialcast::Gitx::CLI.start ['release']
       end
@@ -147,6 +147,36 @@ describe Socialcast::Gitx::CLI do
           "git push origin HEAD",
           "git checkout master",
           "git checkout master",
+          "git pull",
+          "git remote prune origin"
+        ]
+      end
+    end
+
+    context 'with alternative base branch' do
+      before do
+        Socialcast::Gitx::CLI.any_instance.should_receive(:post).with("#worklog releasing FOO to special-master #scgitx")
+        Socialcast::Gitx::CLI.any_instance.should_receive(:yes?).and_return(true)
+        Socialcast::Gitx::CLI.any_instance.stub(:base_branch).and_return('special-master')
+        Socialcast::Gitx::CLI.start ['release']
+      end
+      it 'should post message to socialcast' do end # see expectations
+      it 'should run expected commands' do
+        Socialcast::Gitx::CLI.stubbed_executed_commands.should == [
+          "git pull origin FOO",
+          "git pull origin special-master",
+          "git push origin HEAD",
+          "git checkout special-master",
+          "git pull origin special-master",
+          "git pull . FOO",
+          "git push origin HEAD",
+          "git branch -D staging",
+          "git fetch origin",
+          "git checkout staging",
+          "git pull . special-master",
+          "git push origin HEAD",
+          "git checkout special-master",
+          "git checkout special-master",
           "git pull",
           "git remote prune origin"
         ]


### PR DESCRIPTION
Add support for non-master base branch to assist with release-candidate branches.
