### PR TITLE
refreshing the remote branch

### DIFF
--- a/lib/socialcast-git-extensions/git.rb
+++ b/lib/socialcast-git-extensions/git.rb
@@ -10,10 +10,13 @@ module Socialcast
       end
 
       def assert_in_last_known_good_staging(branch)
-        branches_in_last_known_staging = branches(:remote => true, :merged => "origin/#{last_known_good_staging_branch}")
+        refresh_branch_from_remote last_known_good_staging_branch
+        branches_in_last_known_staging = branches(:remote => true, :merged => true)
         unless branches_in_last_known_staging.include? branch
           raise "Cannot release #{branch} unless it has already been promoted separately to #{staging_branch} and the build has passed."
         end
+      ensure
+        run_cmd "git checkout #{branch}"
       end
 
       # lookup the current branch of the PWD

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "3.1.18"
+    VERSION = "3.1.19"
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -156,7 +156,7 @@ describe Socialcast::Gitx::CLI do
   describe '#release' do
     let(:branches_in_last_known_good_staging) { ['FOO'] }
     before do
-      expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:branches).with(:remote => true, :merged => 'origin/last_known_good_staging').and_return(branches_in_last_known_good_staging)
+      expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:branches).with(:remote => true, :merged => true).and_return(branches_in_last_known_good_staging)
     end
 
     context 'when user rejects release' do
@@ -164,8 +164,8 @@ describe Socialcast::Gitx::CLI do
         expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:yes?).and_return(false)
         Socialcast::Gitx::CLI.start ['release']
       end
-      it 'should run no commands' do
-        expect(Socialcast::Gitx::CLI.stubbed_executed_commands).to eq([])
+      it 'does not try and release the branch' do
+        expect(Socialcast::Gitx::CLI.stubbed_executed_commands).to eq(["git branch -D last_known_good_staging", "git fetch origin", "git checkout last_known_good_staging", "git checkout FOO"])
       end
     end
     context 'when user confirms release' do
@@ -179,6 +179,10 @@ describe Socialcast::Gitx::CLI do
       it 'should post message to socialcast' do end # see expectations
       it 'should run expected commands' do
         expect(Socialcast::Gitx::CLI.stubbed_executed_commands).to eq([
+          "git branch -D last_known_good_staging",
+          "git fetch origin",
+          "git checkout last_known_good_staging",
+          "git checkout FOO",
           "git pull origin FOO",
           "git pull origin master",
           "git push origin HEAD",
@@ -235,6 +239,10 @@ describe Socialcast::Gitx::CLI do
       end
       it 'should run expected commands' do
         expect(Socialcast::Gitx::CLI.stubbed_executed_commands).to eq([
+          "git branch -D last_known_good_staging",
+          "git fetch origin",
+          "git checkout last_known_good_staging",
+          "git checkout FOO",
           "git pull origin FOO",
           "git pull origin special-master",
           "git push origin HEAD",
@@ -271,6 +279,10 @@ describe Socialcast::Gitx::CLI do
       it 'should post message to socialcast' do end # see expectations
       it 'should run expected commands' do
         expect(Socialcast::Gitx::CLI.stubbed_executed_commands).to eq([
+          "git branch -D last_known_good_staging",
+          "git fetch origin",
+          "git checkout last_known_good_staging",
+          "git checkout FOO",
           "git pull origin FOO",
           "git pull origin special-master",
           "git push origin HEAD",
@@ -308,6 +320,10 @@ describe Socialcast::Gitx::CLI do
       it 'should post message to socialcast' do end # see expectations
       it 'should run expected commands' do
         expect(Socialcast::Gitx::CLI.stubbed_executed_commands).to eq([
+          "git branch -D last_known_good_staging",
+          "git fetch origin",
+          "git checkout last_known_good_staging",
+          "git checkout FOO",
           "git pull origin FOO",
           "git pull origin special-master",
           "git push origin HEAD",


### PR DESCRIPTION
per @seanwalbran comment here on 1327409

We need to sure that the user has the most up-to-date `last_known_good_staging` branch before we can try and compare the difference.
