### PR TITLE
do-not-truncate-pr-text

### DIFF
--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -64,8 +64,7 @@ module Socialcast
         url = create_pull_request branch, repo, description, assignee
         say "Pull request created: #{url}"
 
-        short_description = description.split("\n").first(5).join("\n")
-        review_message = ["#reviewrequest for #{branch} #scgitx", "/cc @SocialcastDevelopers", review_mention, short_description, changelog_summary(branch)].compact.join("\n\n")
+        review_message = ["#reviewrequest for #{branch} #scgitx", "/cc @SocialcastDevelopers", review_mention, description, changelog_summary(branch)].compact.join("\n\n")
         post review_message, :url => url, :message_type => 'review_request'
       end
 


### PR DESCRIPTION
When submitting a PR via scgitx that has a long body (like this one), do not truncate the body when posting to socialcast.
If it were truncated,
then important information might be lost,
hindering its usefulness,
in particular,
but not limited to,
at-mentions like:
Assigned to @BrianJohn
