### PR TITLE
update-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 
   `socialcast authenticate --domain (your domain)`
 
-  Where "(your domain)" woudl be the fully qualified domain name of the Socialcast community you will use for work e.g. [er.staging.socialcast.com](https://er.staging.socialcast.com)
+Where "(your domain)" would be the fully qualified domain name of the Socialcast community you will use for work e.g. [er.staging.socialcast.com](https://er.staging.socialcast.com)
+#### GitHub Token Installation
+Some of the extentions provided make use of the GitHub Application Token. When using commands such as [`git findpr`](https://github.com/socialcast/socialcast-git-extensions#git-findpr-) or [`git reviewrequest`](https://github.com/socialcast/socialcast-git-extensions#git-reviewrequest) the extensions will accept the credentials of the GitHub account and then install the GitHub token for you. If the GitHub account has two-factor authentication enabled then a manual installation of the GitHub Token is required.
 
-#### Token Installation
+#### Manual GitHub Token Installation
 Access the [Application settings](https://github.com/settings/applications) of your github.com account and select "*Generate new token*" or use an existing Github Application token. Store the token in  `~/.socialcast/credentials.yml`. Example:
 ```yaml
 ---
@@ -22,6 +24,7 @@ Access the [Application settings](https://github.com/settings/applications) of y
 :password: supersecret
 :scgitx_token: 030000e600000000000000aaaaaaaaabbbbbbbbb
 ```
+
 Test the token with the [`git findpr`](https://github.com/socialcast/socialcast-git-extensions#git-findpr-) command.
 
 ### Options

--- a/README.md
+++ b/README.md
@@ -4,7 +4,25 @@
 # Core Git Extensions
 
 ### Install
-  socialcast authenticate --domain (your domain)
+  `gem install socialcast-git-extensions`
+
+  Test the installation by running
+
+  `socialcast authenticate --domain (your domain)`
+
+  Where "(your domain)" woudl be the fully qualified domain name of the Socialcast community you will use for work e.g. [er.staging.socialcast.com](https://er.staging.socialcast.com)
+
+#### Token Installation
+Access the [Application settings](https://github.com/settings/applications) of your github.com account and select "*Generate new token*" or use an existing Github Application token. Store the token in  `~/.socialcast/credentials.yml`. Example:
+```yaml
+---
+:domain: er.staging.socialcast.com
+:proxy:
+:user: person@example.com
+:password: supersecret
+:scgitx_token: 030000e600000000000000aaaaaaaaabbbbbbbbb
+```
+Test the token with the [`git findpr`](https://github.com/socialcast/socialcast-git-extensions#git-findpr-) command.
 
 ### Options
 * ```--quiet```: suppress posting message in Socialcast


### PR DESCRIPTION
Add Github App Token help to the README.md in the interest of reducing minor obstacles for new members of the engineering team.