### PR TITLE
use set-upstream-to to fix local/remote tracking confusion

### DIFF
--- a/lib/socialcast-git-extensions/git.rb
+++ b/lib/socialcast-git-extensions/git.rb
@@ -104,7 +104,7 @@ module Socialcast
       end
 
       def track_branch(branch)
-        run_cmd "git branch --track origin/#{branch}"
+        run_cmd "git branch --set-upstream-to=origin/#{branch} #{branch}"
       end
 
       # integrate a branch into a destination aggregate branch

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "3.1.31"
+    VERSION = "3.1.32"
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -382,7 +382,7 @@ describe Socialcast::Gitx::CLI do
           "git push origin --delete staging",
           "git checkout -b staging",
           "git push origin staging",
-          "git branch --track origin/staging",
+          "git branch --set-upstream-to=origin/staging staging",
           "git checkout master"
         ])
       end
@@ -404,7 +404,7 @@ describe Socialcast::Gitx::CLI do
           "git push origin --delete qa",
           "git checkout -b qa",
           "git push origin qa",
-          "git branch --track origin/qa",
+          "git branch --set-upstream-to=origin/qa qa",
           "git checkout master"
         ])
       end
@@ -426,7 +426,7 @@ describe Socialcast::Gitx::CLI do
           "git push origin --delete qa",
           "git checkout -b qa",
           "git push origin qa",
-          "git branch --track origin/qa",
+          "git branch --set-upstream-to=origin/qa qa",
           "git checkout master",
           "git checkout master",
           "git branch -D last_known_good_master",
@@ -436,7 +436,7 @@ describe Socialcast::Gitx::CLI do
           "git push origin --delete last_known_good_qa",
           "git checkout -b last_known_good_qa",
           "git push origin last_known_good_qa",
-          "git branch --track origin/last_known_good_qa",
+          "git branch --set-upstream-to=origin/last_known_good_qa last_known_good_qa",
           "git checkout master"
         ])
       end


### PR DESCRIPTION
Previous use of `--track` resulted in local branches named `origin/blah` 

Before:
```
$ git branch --track origin/prototype
Branch origin/prototype set up to track local branch prototype.
```

After:
```
$ git branch --set-upstream-to=origin/prototype prototype
Branch prototype set up to track remote branch prototype from origin.
```