### PR TITLE
git-backportpr-should-refresh-branch-from-remote

### DIFF
--- a/lib/socialcast-git-extensions/git.rb
+++ b/lib/socialcast-git-extensions/git.rb
@@ -39,7 +39,7 @@ module Socialcast
       end
 
       def backport_to(branch, shas)
-        run_cmd "git checkout #{base_branch}"
+        refresh_branch_from_remote(branch)
         run_cmd "git checkout -b #{branch}"
         begin
           run_cmd "git cherry-pick #{shas.join(' ')}"


### PR DESCRIPTION
Update `git-backportpr` behavior to refresh branch from remote when checking it out.