### PR TITLE
Webhook friendliness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tmtags
 coverage
 rdoc
 pkg
+.byebug_history
 
 #bundler
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -50,9 +50,17 @@ Find pull requests on github including a given commit
 
 List branches merged into remote origin/`branch` and not also merged into origin/`base_branch`
 
+## git createpr
+
+create a pull request on github for the current branch, without assigning it for review.
+
 ## git reviewrequest
 
-create a pull request on github for peer review of the current branch.
+create and assign a pull request on github for peer review of the current branch.  See `assignpr` for additional options.
+
+## git assignpr
+
+assign the pull request on github for the current branch for peer review.
 
 ### Optional:
 Specify a Review Buddy mapping that will reference the local Github username and @mention a pre-assigned review buddy in the Socialcast Review Request message.  Specify the mapping by creating a .scgitx YML file relative to the Repo Root: config/scgitx.yml with the following format:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Test the token with the [`git findpr`](https://github.com/socialcast/socialcast-
 
 ### Options
 * ```--quiet```: suppress posting message in Socialcast
+* config/scgitx.yml option `share_via_pr_comments`: Set to `true` to post reviewrequest and integration messages
+as pull request comments instead of Socialcast posts.
 
 ## git start <new_branch_name (optional)>
 

--- a/bin/git-assignpr
+++ b/bin/git-assignpr
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require File.join(File.dirname(__FILE__), '..', 'lib', 'socialcast-git-extensions', 'cli.rb')
+Socialcast::Gitx::CLI.start (['assignpr'] + ARGV)

--- a/bin/git-createpr
+++ b/bin/git-createpr
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require File.join(File.dirname(__FILE__), '..', 'lib', 'socialcast-git-extensions', 'cli.rb')
+Socialcast::Gitx::CLI.start (['createpr'] + ARGV)

--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -335,11 +335,11 @@ module Socialcast
       end
 
       def use_pr_comments?
-        config['comment_via_pull_request'] == true
+        config['share_via_pr_comments'] == true
       end
 
       # post a message in socialcast
-      # skip sharing message if CLI quiet option is present or config quiet option is 'true'
+      # skip sharing message if CLI quiet option is present
       def post(message, params = {})
         return if options[:quiet]
         ActiveResource::Base.logger = Logger.new(STDOUT) if options[:trace]

--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -314,12 +314,14 @@ module Socialcast
         integrate_branch(base_branch, staging_branch)
         cleanup
 
-        message = <<-EOS.strip_heredoc
-          #worklog releasing #{branch} to #{base_branch} in #{current_repo} #scgitx
-          /cc @#{developer_group}
-        EOS
+        unless use_pr_comments?
+          message = <<-EOS.strip_heredoc
+            #worklog releasing #{branch} to #{base_branch} in #{current_repo} #scgitx
+            /cc @#{developer_group}
+          EOS
 
-        post message.strip
+          post message.strip
+        end
       end
 
       private

--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -32,8 +32,7 @@ module Socialcast
       method_option :description, :type => :string, :aliases => '-d', :desc => 'pull request description'
       # @see http://developer.github.com/v3/pulls/
       def createpr
-        update
-
+        update unless @skip_update
         description = options[:description] || editor_input(PULL_REQUEST_DESCRIPTION)
         branch = current_branch
         repo = current_repo
@@ -46,6 +45,8 @@ module Socialcast
       method_option :skip_additional_reviewers, :type => :string, :aliases => '-s', :desc => 'Skips adding additional reviewers'
       # @see http://developer.github.com/v3/pulls/
       def assignpr(*additional_reviewers)
+        update unless @skip_update
+
         primary_mention = if buddy = socialcast_review_buddy(current_user)
           "assigned to @#{buddy}"
         end
@@ -89,6 +90,8 @@ module Socialcast
       method_option :skip_additional_reviewers, :type => :string, :aliases => '-s', :desc => 'Skips adding additional reviewers'
       # @see http://developer.github.com/v3/pulls/
       def reviewrequest(*additional_reviewers)
+        update
+        @skip_update = true
         createpr
         assignpr(*additional_reviewers)
       end

--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -136,7 +136,7 @@ module Socialcast
         pr_hash = create_pull_request(backport_branch, repo, description)
         assign_pull_request(assignee, pr_hash['issue_url']) if assignee
 
-        reviewer_mention = "@#{socialcast_reviwer}" if socialcast_reviewer
+        reviewer_mention = "@#{socialcast_reviewer}" if socialcast_reviewer
         if use_pr_comments?
           issue_message = ['#reviewrequest backport', reviewer_mention, "/cc @#{developer_group} #scgitx"].compact.join(' ')
           comment_on_issue(pr_hash['issue_url'], issue_message)

--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -234,7 +234,7 @@ module Socialcast
         say("WARNING: Unable to find current pull request.  Use `git createpr` to create one.", :red) unless current_pr
 
         if current_pr && !options[:quiet]
-          issue_message = "Integrated into #{target_branch} /cc @#{developer_group} #scgitx"
+          issue_message = "Integrated into #{target_branch}"
           comment_on_issue(current_pr['issue_url'], issue_message)
         end
 

--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -75,7 +75,8 @@ module Socialcast
         issue_url = current_pr['issue_url']
         url = current_pr['html_url']
 
-        assign_pull_request(assignee, issue_url) if assignee = github_review_buddy(current_user)
+        assignee = github_review_buddy(current_user)
+        assign_pull_request(assignee, issue_url) if assignee
 
         issue_message = ['#reviewrequest', primary_mention, secondary_mention, "\n/cc @#{developer_group} #scgitx"].compact.join(' ')
         comment_on_issue(issue_url, issue_message)

--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -330,7 +330,7 @@ module Socialcast
       # post a message in socialcast
       # skip sharing message if CLI quiet option is present or config quiet option is 'true'
       def post(message, params = {})
-        return if (options[:quiet] || config['quiet'] == 'true') && !options[:force_post]
+        return if (options[:quiet] || config['quiet'] == true) && !options[:force_post]
         ActiveResource::Base.logger = Logger.new(STDOUT) if options[:trace]
         Socialcast::CommandLine::Message.configure_from_credentials
         response = Socialcast::CommandLine::Message.create params.merge(:body => message)

--- a/lib/socialcast-git-extensions/github.rb
+++ b/lib/socialcast-git-extensions/github.rb
@@ -53,10 +53,10 @@ module Socialcast
 
       # find the PRs for a given branch
       # https://developer.github.com/v3/pulls/#list-pull-requests
-      def pull_requests_for_branch(branch, repo, options = {})
+      def pull_requests_for_branch(repo, branch, options = {})
         query = "base=#{branch}"
         query = "#{query}&state=#{options[:state]}" if options[:state]
-        github_api_request "GET", "repos/#{repo}/pulls?base=branch"
+        github_api_request "GET", "repos/#{repo}/pulls?base=#{branch}"
       end
 
       # find the current PR for a given branch

--- a/lib/socialcast-git-extensions/github.rb
+++ b/lib/socialcast-git-extensions/github.rb
@@ -53,9 +53,7 @@ module Socialcast
 
       # find the PRs for a given branch
       # https://developer.github.com/v3/pulls/#list-pull-requests
-      def pull_requests_for_branch(repo, branch, options = {})
-        query = "base=#{branch}"
-        query = "#{query}&state=#{options[:state]}" if options[:state]
+      def pull_requests_for_branch(repo, branch)
         head_name = "#{repo.split('/').first}:#{branch}"
         github_api_request "GET", "repos/#{repo}/pulls?head=#{head_name}"
       end

--- a/lib/socialcast-git-extensions/github.rb
+++ b/lib/socialcast-git-extensions/github.rb
@@ -68,7 +68,7 @@ module Socialcast
       end
 
       def assign_pull_request(assignee, issue_url)
-        issue_payload = { :title => branch, :assignee => assignee }.to_json
+        issue_payload = { :assignee => assignee }.to_json
         github_api_request "PATCH", issue_url, issue_payload
       rescue => e
         say "Failed to assign pull request: #{e.message}", :red

--- a/lib/socialcast-git-extensions/github.rb
+++ b/lib/socialcast-git-extensions/github.rb
@@ -67,13 +67,9 @@ module Socialcast
         prs.first
       end
 
-      # returns the issue_url for the PR
-      def assign_pull_request(branch, repo, assignee)
+      def assign_pull_request(assignee, issue_url)
         issue_payload = { :title => branch, :assignee => assignee }.to_json
-        issue_url = current_pr_for_branch(repo, branch)['issue_url']
-        raise "Unable to determine issue_url for branch #{branch} in #{repo}" unless issue_url
         github_api_request "PATCH", issue_url, issue_payload
-        issue_url
       rescue => e
         say "Failed to assign pull request: #{e.message}", :red
       end

--- a/lib/socialcast-git-extensions/github.rb
+++ b/lib/socialcast-git-extensions/github.rb
@@ -56,7 +56,8 @@ module Socialcast
       def pull_requests_for_branch(repo, branch, options = {})
         query = "base=#{branch}"
         query = "#{query}&state=#{options[:state]}" if options[:state]
-        github_api_request "GET", "repos/#{repo}/pulls?base=#{branch}"
+        head_name = "#{repo.split('/').first}:#{branch}"
+        github_api_request "GET", "repos/#{repo}/pulls?head=#{head_name}"
       end
 
       # find the current PR for a given branch

--- a/lib/socialcast-git-extensions/github.rb
+++ b/lib/socialcast-git-extensions/github.rb
@@ -78,8 +78,6 @@ module Socialcast
         github_api_request 'POST', "#{issue_url}/comments", { :body => comment_body }.to_json
       end
 
-      # https://developer.github.com/v3/issues/comments/#create-a-comment
-
       # @returns [String] socialcast username to assign the review to
       # @returns [nil] when no buddy system configured or user not found
       def socialcast_review_buddy(current_user)

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "4.0.beta2"
+    VERSION = "4.0.beta3"
   end
 end

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "4.0.beta4"
+    VERSION = "4.0.beta5"
   end
 end

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "4.0.beta6"
+    VERSION = "4.0.beta7"
   end
 end

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "4.0.beta7"
+    VERSION = "4.0.beta8"
   end
 end

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "3.3"
+    VERSION = "4.0.beta2"
   end
 end

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "4.0.beta3"
+    VERSION = "4.0.beta4"
   end
 end

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "4.0.rc1"
+    VERSION = "4.0"
   end
 end

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "4.0.beta8"
+    VERSION = "4.0.beta9"
   end
 end

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "4.0.beta5"
+    VERSION = "4.0.beta6"
   end
 end

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "4.0.beta9"
+    VERSION = "4.0.rc1"
   end
 end

--- a/socialcast-git-extensions.gemspec
+++ b/socialcast-git-extensions.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'pry', '~>  0.9.12.6'
   s.add_development_dependency 'webmock', '~> 1.21'
+  s.add_development_dependency 'byebug'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/socialcast-git-extensions.gemspec
+++ b/socialcast-git-extensions.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'rugged', '>= 0.23'
   s.add_runtime_dependency 'socialcast', '~> 1.3.0'
-  s.add_runtime_dependency 'activesupport', '~> 4.0'
+  s.add_runtime_dependency 'activesupport', '>= 4.0'
   s.add_runtime_dependency 'rest-client', '~> 1.7'
   s.add_runtime_dependency 'thor', '~> 0.19.1'
   s.add_runtime_dependency 'rake', '~> 10.3'

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1366,7 +1366,7 @@ describe Socialcast::Gitx::CLI do
       expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:branches).with(:merged => true).and_return(['staging', 'bazquux', 'last_known_good_prototype'])
       Socialcast::Gitx::CLI.start ['cleanup']
     end
-    it 'should only cleanup non-reserved branches' do
+    it 'only cleans up non-reserved branches' do
       expect(stubbed_executed_commands).to eq([
         "git checkout master",
         "git pull",

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -150,7 +150,7 @@ describe Socialcast::Gitx::CLI do
 
         stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
           .with(
-            :body => "{\"body\":\"Integrated into prototype /cc @SocialcastDevelopers #scgitx\"}",
+            :body => "{\"body\":\"Integrated into prototype\"}",
           ).to_return(:status => 200, :body => "{}", :headers => {})
 
           Socialcast::Gitx::CLI.start ['integrate']

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Socialcast::Gitx::CLI do
   let(:stubbed_executed_commands) { [] }
 
-  def stub_message(message_body, params = {})
+  def expect_message(message_body, params = {})
     expect(Socialcast::CommandLine::Message).to receive(:create).with(params.merge(:body => message_body)).and_return(double(:permalink_url => 'https://community.socialcast.com/messages/1234'))
   end
 
@@ -39,13 +39,13 @@ describe Socialcast::Gitx::CLI do
 
   describe '#integrate' do
     context 'with no existing pull request' do
-      before do
+      let!(:github_api_pulls_list) do
         stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
           .to_return(:status => 200, :body => "[]", :headers => {})
       end
       context 'when target branch is omitted' do
         it 'defaults to prototype' do
-          stub_message "#worklog integrating FOO into prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+          expect_message "#worklog integrating FOO into prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
 
           Socialcast::Gitx::CLI.start ['integrate']
 
@@ -61,13 +61,14 @@ describe Socialcast::Gitx::CLI do
                                                     "git checkout FOO",
                                                     "git checkout FOO"
                                                   ])
+          expect(github_api_pulls_list).to have_been_requested
         end
       end
       context 'when target branch is omitted with custom prototype branch' do
         it 'defaults to the custom prototype branch' do
           allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:prototype_branch).and_return('special-prototype')
 
-          stub_message "#worklog integrating FOO into special-prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+          expect_message "#worklog integrating FOO into special-prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
 
           Socialcast::Gitx::CLI.start ['integrate']
 
@@ -87,7 +88,7 @@ describe Socialcast::Gitx::CLI do
       end
       context 'when target branch == prototype' do
         it do
-          stub_message "#worklog integrating FOO into prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+          expect_message "#worklog integrating FOO into prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
 
           Socialcast::Gitx::CLI.start ['integrate', 'prototype']
 
@@ -107,7 +108,7 @@ describe Socialcast::Gitx::CLI do
       end
       context 'when target branch == staging' do
         it do
-          stub_message "#worklog integrating FOO into staging in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+          expect_message "#worklog integrating FOO into staging in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
 
           Socialcast::Gitx::CLI.start ['integrate', 'staging']
 
@@ -140,31 +141,61 @@ describe Socialcast::Gitx::CLI do
       end
     end
     context 'with an existing pull request' do
-      before do
+      let!(:github_api_pulls_list) do
         stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
           .to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]))
       end
-      it 'comments on the PR and does not force a post' do
-        stub_message "#worklog integrating FOO into prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
-
+      let!(:github_api_comments_create) do
         stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
           .with(:body => "{\"body\":\"Integrated into prototype\"}")
           .to_return(:status => 200, :body => "{}", :headers => {})
-
+      end
+      context 'when use_pr_comments? is false' do
+        before do
+          allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:use_pr_comments?).and_return(false)
+        end
+        it 'does not comment on the PR posts a message' do
+          expect_message "#worklog integrating FOO into prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
           Socialcast::Gitx::CLI.start ['integrate']
 
           expect(stubbed_executed_commands).to eq([
-                                                    "git pull origin FOO",
-                                                    "git pull origin master",
-                                                    "git push origin HEAD",
-                                                    "git branch -D prototype",
-                                                    "git fetch origin",
-                                                    "git checkout prototype",
-                                                    "git pull . FOO",
-                                                    "git push origin HEAD",
-                                                    "git checkout FOO",
-                                                    "git checkout FOO"
-                                                  ])
+            "git pull origin FOO",
+            "git pull origin master",
+            "git push origin HEAD",
+            "git branch -D prototype",
+            "git fetch origin",
+            "git checkout prototype",
+            "git pull . FOO",
+            "git push origin HEAD",
+            "git checkout FOO",
+            "git checkout FOO"
+          ])
+          expect(github_api_pulls_list).to have_been_requested
+          expect(github_api_comments_create).to_not have_been_requested
+        end
+      end
+      context 'when use_pr_comments? is true' do
+        before do
+          allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:use_pr_comments?).and_return(true)
+        end
+        it 'comments on the PR and does not post a message' do
+          Socialcast::Gitx::CLI.start ['integrate']
+
+          expect(stubbed_executed_commands).to eq([
+            "git pull origin FOO",
+            "git pull origin master",
+            "git push origin HEAD",
+            "git branch -D prototype",
+            "git fetch origin",
+            "git checkout prototype",
+            "git pull . FOO",
+            "git push origin HEAD",
+            "git checkout FOO",
+            "git checkout FOO"
+          ])
+          expect(github_api_pulls_list).to have_been_requested
+          expect(github_api_comments_create).to have_been_requested
+        end
       end
     end
   end
@@ -186,37 +217,53 @@ describe Socialcast::Gitx::CLI do
       end
     end
     context 'when user confirms release' do
-      it do
-        stub_message "#worklog releasing FOO to master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
-
+      before do
         expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:yes?).and_return(true)
         expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:cleanup)
-        Socialcast::Gitx::CLI.start ['release']
-
-        expect(stubbed_executed_commands).to eq([
-          "git branch -D last_known_good_staging",
-          "git fetch origin",
-          "git checkout last_known_good_staging",
-          "git checkout FOO",
-          "git pull origin FOO",
-          "git pull origin master",
-          "git push origin HEAD",
-          "git checkout master",
-          "git pull origin master",
-          "git pull . FOO",
-          "git push origin HEAD",
-          "git branch -D staging",
-          "git fetch origin",
-          "git checkout staging",
-          "git pull . master",
-          "git push origin HEAD",
-          "git checkout master"
-        ])
+      end
+      shared_examples_for 'releasing the branch' do
+        it do
+          expect(stubbed_executed_commands).to eq([
+            "git branch -D last_known_good_staging",
+            "git fetch origin",
+            "git checkout last_known_good_staging",
+            "git checkout FOO",
+            "git pull origin FOO",
+            "git pull origin master",
+            "git push origin HEAD",
+            "git checkout master",
+            "git pull origin master",
+            "git pull . FOO",
+            "git push origin HEAD",
+            "git branch -D staging",
+            "git fetch origin",
+            "git checkout staging",
+            "git pull . master",
+            "git push origin HEAD",
+            "git checkout master"
+          ])
+        end
+      end
+      context 'when use_pr_comments? is false' do
+        before do
+          allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:use_pr_comments?).and_return(false)
+          expect_message "#worklog releasing FOO to master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+          Socialcast::Gitx::CLI.start ['release']
+        end
+        it_behaves_like 'releasing the branch'
+      end
+      context 'when use_pr_comments? is true' do
+        before do
+          allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:use_pr_comments?).and_return(true)
+          Socialcast::Gitx::CLI.start ['release']
+        end
+        # does not post a message nor a pr comment (github reports "merged" event via webhook)'
+        it_behaves_like 'releasing the branch'
       end
     end
 
     context 'when the branch is not in last_known_good_staging' do
-      context 'and enforce_staging_before_release = true' do
+      context 'when enforce_staging_before_release = true' do
         let(:branches_in_last_known_good_staging) { ['another-branch'] }
         before do
           expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:enforce_staging_before_release?).and_return(true)
@@ -226,16 +273,16 @@ describe Socialcast::Gitx::CLI do
           expect { Socialcast::Gitx::CLI.start ['release'] }.to raise_error(RuntimeError, 'Cannot release FOO unless it has already been promoted separately to staging and the build has passed.')
         end
       end
-      context 'and enforce_staging_before_release = false' do
+      context 'when enforce_staging_before_release = false' do
         let(:branches_in_last_known_good_staging) { ['another-branch'] }
         before do
-          stub_message "#worklog releasing FOO to master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+          expect_message "#worklog releasing FOO to master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
           expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:enforce_staging_before_release?).and_return(false)
           expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:yes?).and_return(true)
           expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:cleanup)
           Socialcast::Gitx::CLI.start ['release']
         end
-        it 'should run expected commands' do
+        it do
           expect(stubbed_executed_commands).to eq([
             "git pull origin FOO",
             "git pull origin master",
@@ -257,9 +304,9 @@ describe Socialcast::Gitx::CLI do
 
     context 'with reserved_branches via config file' do
       before do
-        stub_message "#worklog releasing FOO to master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+        expect_message "#worklog releasing FOO to master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
         expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:yes?).and_return(true)
-        allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return( { 'reserved_branches' => ['dont-del-me','dont-del-me-2'] })
+        allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return('reserved_branches' => ['dont-del-me', 'dont-del-me-2'])
         expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:cleanup)
         Socialcast::Gitx::CLI.start ['release']
       end
@@ -271,10 +318,10 @@ describe Socialcast::Gitx::CLI do
 
     context 'with alternative base branch via config file' do
       it do
-        stub_message "#worklog releasing FOO to special-master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+        expect_message "#worklog releasing FOO to special-master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
 
         expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:yes?).and_return(true)
-        allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return( { 'base_branch' => 'special-master' })
+        allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return('base_branch' => 'special-master')
         expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:cleanup)
         Socialcast::Gitx::CLI.start ['release']
 
@@ -304,7 +351,7 @@ describe Socialcast::Gitx::CLI do
 
     context 'with alternative base branch via environment variable' do
       before do
-        stub_message "#worklog releasing FOO to special-master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+        expect_message "#worklog releasing FOO to special-master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
 
         expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:yes?).and_return(true)
         allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return({})
@@ -342,10 +389,10 @@ describe Socialcast::Gitx::CLI do
 
     context 'with alternative base branch via environment variable overriding base branch in config' do
       before do
-        stub_message "#worklog releasing FOO to special-master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+        expect_message "#worklog releasing FOO to special-master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
 
         expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:yes?).and_return(true)
-        allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return({ 'base_branch' => 'extra-special-master' })
+        allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return('base_branch' => 'extra-special-master')
         expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:cleanup)
         ENV['BASE_BRANCH'] = 'special-master'
         Socialcast::Gitx::CLI.start ['release']
@@ -425,10 +472,10 @@ describe Socialcast::Gitx::CLI do
     before { allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:branches).and_return([]) }
     context 'when target branch == staging and --destination == last_known_good_staging' do
       before do
-        stub_message "#worklog resetting staging branch to last_known_good_staging in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+        expect_message "#worklog resetting staging branch to last_known_good_staging in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
         Socialcast::Gitx::CLI.start ['nuke', 'staging', '--destination', 'last_known_good_staging']
       end
-      it 'should run expected commands' do
+      it do
         expect(stubbed_executed_commands).to eq([
           "git checkout master",
           "git branch -D last_known_good_staging",
@@ -445,12 +492,12 @@ describe Socialcast::Gitx::CLI do
     end
     context 'when target branch == qa and destination prompt == nil and using custom aggregate_branches config' do
       before do
-        stub_message "#worklog resetting qa branch to last_known_good_qa in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
-        allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return( { 'aggregate_branches' => ['staging', 'qa'] })
+        expect_message "#worklog resetting qa branch to last_known_good_qa in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+        allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return('aggregate_branches' => ['staging', 'qa'])
         expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:ask).and_return('')
         Socialcast::Gitx::CLI.start ['nuke', 'qa']
       end
-      it 'defaults to last_known_good_qa and should run expected commands' do
+      it 'defaults to last_known_good_qa' do
         expect(stubbed_executed_commands).to eq([
           "git checkout master",
           "git branch -D last_known_good_qa",
@@ -467,12 +514,12 @@ describe Socialcast::Gitx::CLI do
     end
     context 'when target branch == qa and destination prompt = master and using custom aggregate_branches config' do
       before do
-        stub_message "#worklog resetting qa branch to last_known_good_master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
-        allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return( { 'aggregate_branches' => ['staging', 'qa'] })
+        expect_message "#worklog resetting qa branch to last_known_good_master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+        allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return('aggregate_branches' => ['staging', 'qa'])
         expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:ask).and_return('master')
         Socialcast::Gitx::CLI.start ['nuke', 'qa']
       end
-      it 'should run expected commands' do
+      it do
         expect(stubbed_executed_commands).to eq([
           "git checkout master",
           "git branch -D last_known_good_master",
@@ -498,17 +545,17 @@ describe Socialcast::Gitx::CLI do
       end
     end
     it 'raises an error when target branch is not an aggregate branch' do
+      expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:ask).and_return('master')
       expect {
-        expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:ask).and_return('master')
         Socialcast::Gitx::CLI.start ['nuke', 'asdfasdf']
       }.to raise_error(/Only aggregate branches are allowed to be reset/)
     end
   end
 
   describe '#backportpr' do
-    before do
+    let(:pr_response) do
       # https://developer.github.com/v3/search/#search-issues
-      pr_response = {
+      {
         "url" => "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls/59",
         "id" => 13712197,
         "html_url" => "https://github.com/socialcast/socialcast-git-extensions/pull/59",
@@ -807,8 +854,9 @@ describe Socialcast::Gitx::CLI do
         "deletions" => 2,
         "changed_files" => 2
       }
-
-      commits_response = [
+    end
+    let(:commits_response) do
+      [
         {
           "sha" => "5e30d5af3f4d1bb3a34cc97568299be028b65f6f",
           "commit" => {
@@ -880,33 +928,63 @@ describe Socialcast::Gitx::CLI do
           ]
         }
       ]
-
+    end
+    let!(:github_pr_show) do
       stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls/59")
         .to_return(:status => 200, :body => pr_response.to_json, :headers => {})
+    end
+    let!(:github_pr_commits_list) do
       stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls/59/commits")
         .to_return(:status => 200, :body => commits_response.to_json, :headers => {})
+    end
+    let!(:github_pr_create) do
       stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls")
         .with(:body => "{\"title\":\"backport_59_to_v1.x\",\"base\":\"v1.x\",\"head\":\"backport_59_to_v1.x\",\"body\":\"Backport #59 to https://github.com/socialcast/socialcast-git-extensions/tree/v1.x\\n***\\nsimply testing this out\"}")
         .to_return(:status => 200, :body => '{"html_url": "https://github.com/socialcast/socialcast-git-extensions/pulls/60", "issue_url": "https://api.github.com/repos/repo/project/issues/60"}', :headers => { 'Content-Type' => 'application/json' })
-
+    end
+    let!(:github_pr_comment_create) do
       stub_request(:post, "https://api.github.com/repos/repo/project/issues/60/comments")
         .with(:body => "{\"body\":\"#reviewrequest backport /cc @SocialcastDevelopers #scgitx\"}")
         .to_return(:status => 200, :body => "{}", :headers => {})
-
+    end
+    let!(:socialcast_message_create) do
       stub_request(:post, "https://testuser:testpassword@testdomain/api/messages.json")
         .with(:body => "{\"message\":{\"url\":\"https://github.com/socialcast/socialcast-git-extensions/pulls/60\",\"message_type\":\"review_request\",\"body\":\"#reviewrequest backport #59 to v1.x in socialcast/socialcast-git-extensions #scgitx\\n\\n/cc @SocialcastDevelopers\"}}")
         .to_return(:status => 200, :body => "", :headers => {})
-
+    end
+    before do
       expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:backportpr).and_call_original
+      allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:use_pr_comments?).and_return(use_pr_comments)
       Socialcast::Gitx::CLI.start ['backportpr', '59', 'v1.x']
     end
-    it 'creates a branch based on v1.x and cherry-picks in PR 59' do end
+    context 'when use_pr_comments? is false' do
+      let(:use_pr_comments) { false }
+      it 'creates a branch based on v1.x and cherry-picks in PR 59' do
+        expect(github_pr_show).to have_been_requested
+        expect(github_pr_commits_list).to have_been_requested
+        expect(github_pr_create).to have_been_requested
+
+        expect(github_pr_comment_create).to_not have_been_requested
+        expect(socialcast_message_create).to have_been_requested
+      end
+    end
+    context 'when use_pr_comments? is true' do
+      let(:use_pr_comments) { true }
+      it 'posts a pr comment instead of posting a socialcast message' do
+        expect(github_pr_show).to have_been_requested
+        expect(github_pr_commits_list).to have_been_requested
+        expect(github_pr_create).to have_been_requested
+
+        expect(github_pr_comment_create).to have_been_requested
+        expect(socialcast_message_create).to_not have_been_requested
+      end
+    end
   end
 
   describe '#findpr' do
-    before do
+    let(:issue_response) do
       # https://developer.github.com/v3/search/#search-issues
-      stub_response = {
+      {
         "total_count"=> 280,
         "items"=> [{
                      "url" => "https://api.github.com/repos/batterseapower/pinyin-toolkit/issues/132",
@@ -956,93 +1034,154 @@ describe Socialcast::Gitx::CLI do
                      "score" => 1.3859273
                    }]
       }
-
+    end
+    let!(:github_issue_search) do
       stub_request(:get, "https://api.github.com/search/issues?q=abc123%20type:pr%20repo:socialcast/socialcast-git-extensions")
-        .to_return(:status => 200, :body => stub_response.to_json, :headers => {})
+        .to_return(:status => 200, :body => issue_response.to_json, :headers => {})
+    end
+    it do
       expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:findpr).and_call_original
       allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:say).with("Searching github pull requests for abc123")
       allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:say).with("\nhttps://github.com/batterseapower/pinyin-toolkit/issues/132\n\tLine Number Indexes Beyond 20 Not Displayed\n\tNick3C 2009-07-12T20:10:41Z")
       Socialcast::Gitx::CLI.start ['findpr', 'abc123']
+      expect(github_issue_search).to have_been_requested
     end
-    it 'fetches the data from github and prints it out' do end
   end
 
   describe '#reviewrequest' do
+    let(:git_update_commands) do
+      [
+        "git pull origin FOO",
+        "git pull origin master",
+        "git push origin HEAD"
+      ]
+    end
+    let!(:github_create_pr) do
+      stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls")
+        .to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
+    end
+    let!(:github_find_pr_for_branch) do
+      stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
+        .to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
+    end
+    let(:stub_github_create_pr_comment) do
+      stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
+        .with(:body => pr_comment_body)
+        .to_return(:status => 200, :body => "{}", :headers => {})
+    end
+    let(:use_pr_comments) { false }
+    before do
+      stub_github_create_pr_comment
+      allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:use_pr_comments?).and_return(use_pr_comments)
+    end
     context 'when there are no review_buddies specified' do
       before do
         allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config_file).and_return(Pathname(''))
       end
-      context 'when description != nil' do
+      let(:pr_comment_body) { "{\"body\":\"#reviewrequest \\n/cc @SocialcastDevelopers #scgitx\"}" }
+      context 'when use_pr_comments? is false' do
         it do
-          stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls")
-            .to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
-
-          stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
-            .to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
-
-          stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
-            .with(:body => "{\"body\":\"#reviewrequest \\n/cc @SocialcastDevelopers #scgitx\"}")
-            .to_return(:status => 200, :body => "{}", :headers => {})
-
-          stub_message "#reviewrequest for FOO in socialcast/socialcast-git-extensions\nPR http://github.com/repo/project/pulls/1 \n\ntesting\n\n/cc @SocialcastDevelopers #scgitx\n\n1 file changed", :message_type => 'review_request'
+          expect_message "#reviewrequest for FOO in socialcast/socialcast-git-extensions\nPR http://github.com/repo/project/pulls/1 \n\ntesting\n\n/cc @SocialcastDevelopers #scgitx\n\n1 file changed", :message_type => 'review_request'
           allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:changelog_summary).and_return('1 file changed')
           Socialcast::Gitx::CLI.start ['reviewrequest', '--description', 'testing', '-s']
 
-          expect(stubbed_executed_commands).to eq([
-            "git pull origin FOO",
-            "git pull origin master",
-            "git push origin HEAD"
-          ])
+          expect(stubbed_executed_commands).to eq(git_update_commands)
+          expect(github_create_pr).to have_been_requested
+          expect(github_find_pr_for_branch).to have_been_requested
+
+          expect(stub_github_create_pr_comment).to_not have_been_requested
+        end
+      end
+      context 'when use_pr_comments? is true' do
+        let(:use_pr_comments) { true }
+        it do
+          allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:changelog_summary).and_return('1 file changed')
+          Socialcast::Gitx::CLI.start ['reviewrequest', '--description', 'testing', '-s']
+
+          expect(stubbed_executed_commands).to eq(git_update_commands)
+          expect(github_create_pr).to have_been_requested
+          expect(github_find_pr_for_branch).to have_been_requested
+
+          expect(stub_github_create_pr_comment).to have_been_requested
         end
       end
     end
 
     context 'when review_buddies are specified via a /config YML file' do
+      let!(:github_assign_pr) { stub_request(:patch, "http://api.github.com/repos/repo/project/issues/1").to_return(:status => 200) }
       before do
-        stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls")
-          .to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
-        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
-          .to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
-        stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
-          .with(:body => pr_comment_body)
-          .to_return(:status => 200, :body => "{}", :headers => {})
-
-        stub_request(:patch, "http://github.com/repos/repo/project/issues/1").to_return(:status => 200)
         allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:socialcast_review_buddy).and_return('JaneDoe')
+        allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:github_review_buddy).and_return('janedoe')
+        allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:changelog_summary).and_return('1 file changed')
       end
       context 'and additional reviewers are specified' do
         let(:message_body) { "#reviewrequest for FOO in socialcast/socialcast-git-extensions\nPR http://github.com/repo/project/pulls/1 assigned to @JaneDoe\n\ntesting\n\nAssigned additionally to @JohnSmith for API review\n/cc @SocialcastDevelopers #scgitx\n\n1 file changed" }
         let(:pr_comment_body) { "{\"body\":\"#reviewrequest assigned to @JaneDoe \\nAssigned additionally to @JohnSmith for API review \\n/cc @SocialcastDevelopers #scgitx\"}" }
-        it do
-          allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:changelog_summary).and_return('1 file changed')
-          stub_message message_body, :message_type => 'review_request'
-          Socialcast::Gitx::CLI.start ['reviewrequest', '--description', 'testing', '-a', 'a']
+        context 'when use_pr_comments? is false' do
+          it do
+            expect_message message_body, :message_type => 'review_request'
+            Socialcast::Gitx::CLI.start ['reviewrequest', '--description', 'testing', '-a', 'a']
 
-          expect(stubbed_executed_commands).to eq([
-            "git pull origin FOO",
-            "git pull origin master",
-            "git push origin HEAD"
-          ])
+            expect(stubbed_executed_commands).to eq(git_update_commands)
+            expect(github_assign_pr).to have_been_requested
+
+            expect(stub_github_create_pr_comment).to_not have_been_requested
+          end
+        end
+        context 'when use_pr_comments? is true' do
+          let(:use_pr_comments) { true }
+          it do
+            Socialcast::Gitx::CLI.start ['reviewrequest', '--description', 'testing', '-a', 'a']
+
+            expect(stubbed_executed_commands).to eq(git_update_commands)
+            expect(github_assign_pr).to have_been_requested
+
+            expect(stub_github_create_pr_comment).to have_been_requested
+          end
         end
       end
       context 'and a developer group is specified' do
         let(:message_body) { "#reviewrequest for FOO in socialcast/socialcast-git-extensions\nPR http://github.com/repo/project/pulls/1 assigned to @JaneDoe\n\ntesting\n\n/cc @#{another_group} #scgitx\n\n1 file changed" }
         let(:pr_comment_body) { "{\"body\":\"#reviewrequest assigned to @JaneDoe \\n/cc @#{another_group} #scgitx\"}" }
         let(:another_group) { 'AnotherDeveloperGroup' }
-        it do
-          allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:changelog_summary).and_return('1 file changed')
+        before do
           allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return({'developer_group' => another_group})
-          stub_message message_body, :message_type => 'review_request'
-          Socialcast::Gitx::CLI.start ['reviewrequest', '--description', 'testing', '-s']
+        end
+        context 'when use_pr_comments? is false' do
+          it do
+            expect_message message_body, :message_type => 'review_request'
+            Socialcast::Gitx::CLI.start ['reviewrequest', '--description', 'testing', '-s']
+            expect(github_assign_pr).to have_been_requested
+            expect(stub_github_create_pr_comment).to_not have_been_requested
+          end
+        end
+        context 'when use_pr_comments? is true' do
+          let(:use_pr_comments) { true }
+          it do
+            Socialcast::Gitx::CLI.start ['reviewrequest', '--description', 'testing', '-s']
+            expect(github_assign_pr).to have_been_requested
+            expect(stub_github_create_pr_comment).to have_been_requested
+          end
         end
       end
       context 'and additional reviewers are not specified' do
         let(:message_body) { "#reviewrequest for FOO in socialcast/socialcast-git-extensions\nPR http://github.com/repo/project/pulls/1 assigned to @JaneDoe\n\ntesting\n\n/cc @SocialcastDevelopers #scgitx\n\n1 file changed" }
         let(:pr_comment_body) { "{\"body\":\"#reviewrequest assigned to @JaneDoe \\n/cc @SocialcastDevelopers #scgitx\"}" }
-        it do
-          allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:changelog_summary).and_return('1 file changed')
-          stub_message message_body, :message_type => 'review_request'
-          Socialcast::Gitx::CLI.start ['reviewrequest', '--description', 'testing', '-s']
+        context 'when use_pr_comments? is false' do
+          it do
+            expect_message message_body, :message_type => 'review_request'
+            Socialcast::Gitx::CLI.start ['reviewrequest', '--description', 'testing', '-s']
+            expect(github_assign_pr).to have_been_requested
+            expect(stub_github_create_pr_comment).to_not have_been_requested
+          end
+        end
+        context 'when use_pr_comments? is true' do
+          let(:use_pr_comments) { true }
+          it do
+            Socialcast::Gitx::CLI.start ['reviewrequest', '--description', 'testing', '-s']
+            expect(github_assign_pr).to have_been_requested
+            expect(stub_github_create_pr_comment).to have_been_requested
+          end
         end
       end
     end
@@ -1081,7 +1220,7 @@ describe Socialcast::Gitx::CLI do
           .with(:body => "{\"body\":\"#reviewrequest \\n/cc @SocialcastDevelopers #scgitx\"}")
           .to_return(:status => 200, :body => "{}", :headers => {})
 
-        stub_message "#reviewrequest for FOO in socialcast/socialcast-git-extensions\nPR http://github.com/repo/project/pulls/1 \n\ntesting\n\n/cc @SocialcastDevelopers #scgitx\n\n1 file changed", :message_type => 'review_request'
+        expect_message "#reviewrequest for FOO in socialcast/socialcast-git-extensions\nPR http://github.com/repo/project/pulls/1 \n\ntesting\n\n/cc @SocialcastDevelopers #scgitx\n\n1 file changed", :message_type => 'review_request'
         allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:changelog_summary).and_return('1 file changed')
         Socialcast::Gitx::CLI.start ['assignpr', '-s']
 
@@ -1109,7 +1248,7 @@ describe Socialcast::Gitx::CLI do
         let(:pr_comment_body) { "{\"body\":\"#reviewrequest assigned to @JaneDoe \\nAssigned additionally to @JohnSmith for API review \\n/cc @SocialcastDevelopers #scgitx\"}" }
         it do
           allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:changelog_summary).and_return('1 file changed')
-          stub_message message_body, :message_type => 'review_request'
+          expect_message message_body, :message_type => 'review_request'
           Socialcast::Gitx::CLI.start ['assignpr', '-a', 'a']
 
           expect(stubbed_executed_commands).to eq([
@@ -1126,7 +1265,7 @@ describe Socialcast::Gitx::CLI do
         it do
           allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:changelog_summary).and_return('1 file changed')
           allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config).and_return({'developer_group' => another_group})
-          stub_message message_body, :message_type => 'review_request'
+          expect_message message_body, :message_type => 'review_request'
           Socialcast::Gitx::CLI.start ['assignpr', '-s']
         end
       end
@@ -1135,7 +1274,7 @@ describe Socialcast::Gitx::CLI do
         let(:pr_comment_body) { "{\"body\":\"#reviewrequest assigned to @JaneDoe \\n/cc @SocialcastDevelopers #scgitx\"}" }
         it do
           allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:changelog_summary).and_return('1 file changed')
-          stub_message message_body, :message_type => 'review_request'
+          expect_message message_body, :message_type => 'review_request'
           Socialcast::Gitx::CLI.start ['assignpr', '-s']
         end
       end
@@ -1147,7 +1286,7 @@ describe Socialcast::Gitx::CLI do
       stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
         .to_return(:status => 200, :body => "[]", :headers => {})
 
-      stub_message "#worklog integrating FOO into staging in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
+      expect_message "#worklog integrating FOO into staging in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
       Socialcast::Gitx::CLI.start ['promote']
     end
     it 'should integrate into staging' do

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -40,7 +40,7 @@ describe Socialcast::Gitx::CLI do
   describe '#integrate' do
     context 'with no existing pull request' do
       before do
-        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO")
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
           .with(:headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'token faketoken', 'Content-Type'=>'application/json', 'User-Agent'=>'socialcast-git-extensions'})
           .to_return(:status => 200, :body => "[]", :headers => {})
       end
@@ -142,7 +142,7 @@ describe Socialcast::Gitx::CLI do
     end
     context 'with an existing pull request' do
       before do
-        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO")
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
           .to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]))
       end
       it 'comments on the PR and does not force a post' do
@@ -987,7 +987,7 @@ describe Socialcast::Gitx::CLI do
           stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls").
             to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
 
-          stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO").
+          stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO").
             to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
 
           stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
@@ -1013,7 +1013,7 @@ describe Socialcast::Gitx::CLI do
       before do
         stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls").
           to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
-        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO").
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO").
           to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
         stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
           .with(
@@ -1088,7 +1088,7 @@ describe Socialcast::Gitx::CLI do
         allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config_file).and_return(Pathname(''))
       end
       it do
-        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO").
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO").
           to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
 
         stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
@@ -1111,7 +1111,7 @@ describe Socialcast::Gitx::CLI do
 
     context 'when review_buddies are specified via a /config YML file' do
       before do
-        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO").
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO").
           to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
         stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
           .with(
@@ -1162,7 +1162,7 @@ describe Socialcast::Gitx::CLI do
 
   describe '#promote' do
     before do
-      stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO")
+      stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
         .with(:headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'token faketoken', 'Content-Type'=>'application/json', 'User-Agent'=>'socialcast-git-extensions'})
         .to_return(:status => 200, :body => "[]", :headers => {})
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -40,7 +40,7 @@ describe Socialcast::Gitx::CLI do
   describe '#integrate' do
     context 'with no existing pull request' do
       before do
-        stub_request(:get, "https://api.github.com/repos/FOO/pulls?base=branch")
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO")
           .with(:headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'token faketoken', 'Content-Type'=>'application/json', 'User-Agent'=>'socialcast-git-extensions'})
           .to_return(:status => 200, :body => "[]", :headers => {})
       end
@@ -142,7 +142,7 @@ describe Socialcast::Gitx::CLI do
     end
     context 'with an existing pull request' do
       before do
-        stub_request(:get, "https://api.github.com/repos/FOO/pulls?base=branch")
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO")
           .to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]))
       end
       it 'comments on the PR and does not force a post' do
@@ -987,7 +987,7 @@ describe Socialcast::Gitx::CLI do
           stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls").
             to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
 
-          stub_request(:get, "https://api.github.com/repos/FOO/pulls?base=branch").
+          stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO").
             to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
 
           stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
@@ -1013,7 +1013,7 @@ describe Socialcast::Gitx::CLI do
       before do
         stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls").
           to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
-        stub_request(:get, "https://api.github.com/repos/FOO/pulls?base=branch").
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO").
           to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
         stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
           .with(
@@ -1088,7 +1088,7 @@ describe Socialcast::Gitx::CLI do
         allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config_file).and_return(Pathname(''))
       end
       it do
-        stub_request(:get, "https://api.github.com/repos/FOO/pulls?base=branch").
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO").
           to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
 
         stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
@@ -1111,7 +1111,7 @@ describe Socialcast::Gitx::CLI do
 
     context 'when review_buddies are specified via a /config YML file' do
       before do
-        stub_request(:get, "https://api.github.com/repos/FOO/pulls?base=branch").
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO").
           to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
         stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
           .with(
@@ -1162,7 +1162,7 @@ describe Socialcast::Gitx::CLI do
 
   describe '#promote' do
     before do
-      stub_request(:get, "https://api.github.com/repos/FOO/pulls?base=branch")
+      stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?base=FOO")
         .with(:headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'token faketoken', 'Content-Type'=>'application/json', 'User-Agent'=>'socialcast-git-extensions'})
         .to_return(:status => 200, :body => "[]", :headers => {})
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -58,17 +58,17 @@ describe Socialcast::Gitx::CLI do
           Socialcast::Gitx::CLI.start ['integrate']
 
           expect(stubbed_executed_commands).to eq([
-                                                    "git pull origin FOO",
-                                                    "git pull origin master",
-                                                    "git push origin HEAD",
-                                                    "git branch -D prototype",
-                                                    "git fetch origin",
-                                                    "git checkout prototype",
-                                                    "git pull . FOO",
-                                                    "git push origin HEAD",
-                                                    "git checkout FOO",
-                                                    "git checkout FOO"
-                                                  ])
+            "git pull origin FOO",
+            "git pull origin master",
+            "git push origin HEAD",
+            "git branch -D prototype",
+            "git fetch origin",
+            "git checkout prototype",
+            "git pull . FOO",
+            "git push origin HEAD",
+            "git checkout FOO",
+            "git checkout FOO"
+          ])
           expect(github_api_pulls_list).to have_been_requested
         end
       end
@@ -81,17 +81,17 @@ describe Socialcast::Gitx::CLI do
           Socialcast::Gitx::CLI.start ['integrate']
 
           expect(stubbed_executed_commands).to eq([
-                                                    "git pull origin FOO",
-                                                    "git pull origin master",
-                                                    "git push origin HEAD",
-                                                    "git branch -D special-prototype",
-                                                    "git fetch origin",
-                                                    "git checkout special-prototype",
-                                                    "git pull . FOO",
-                                                    "git push origin HEAD",
-                                                    "git checkout FOO",
-                                                    "git checkout FOO"
-                                                  ])
+            "git pull origin FOO",
+            "git pull origin master",
+            "git push origin HEAD",
+            "git branch -D special-prototype",
+            "git fetch origin",
+            "git checkout special-prototype",
+            "git pull . FOO",
+            "git push origin HEAD",
+            "git checkout FOO",
+            "git checkout FOO"
+          ])
         end
       end
       context 'when target branch == prototype' do
@@ -101,17 +101,17 @@ describe Socialcast::Gitx::CLI do
           Socialcast::Gitx::CLI.start ['integrate', 'prototype']
 
           expect(stubbed_executed_commands).to eq([
-                                                    "git pull origin FOO",
-                                                    "git pull origin master",
-                                                    "git push origin HEAD",
-                                                    "git branch -D prototype",
-                                                    "git fetch origin",
-                                                    "git checkout prototype",
-                                                    "git pull . FOO",
-                                                    "git push origin HEAD",
-                                                    "git checkout FOO",
-                                                    "git checkout FOO"
-                                                  ])
+            "git pull origin FOO",
+            "git pull origin master",
+            "git push origin HEAD",
+            "git branch -D prototype",
+            "git fetch origin",
+            "git checkout prototype",
+            "git pull . FOO",
+            "git push origin HEAD",
+            "git checkout FOO",
+            "git checkout FOO"
+          ])
         end
       end
       context 'when target branch == staging' do
@@ -121,23 +121,23 @@ describe Socialcast::Gitx::CLI do
           Socialcast::Gitx::CLI.start ['integrate', 'staging']
 
           expect(stubbed_executed_commands).to eq([
-                                                    "git pull origin FOO",
-                                                    "git pull origin master",
-                                                    "git push origin HEAD",
-                                                    "git branch -D staging",
-                                                    "git fetch origin",
-                                                    "git checkout staging",
-                                                    "git pull . FOO",
-                                                    "git push origin HEAD",
-                                                    "git checkout FOO",
-                                                    "git branch -D prototype",
-                                                    "git fetch origin",
-                                                    "git checkout prototype",
-                                                    "git pull . staging",
-                                                    "git push origin HEAD",
-                                                    "git checkout staging",
-                                                    "git checkout FOO"
-                                                  ])
+            "git pull origin FOO",
+            "git pull origin master",
+            "git push origin HEAD",
+            "git branch -D staging",
+            "git fetch origin",
+            "git checkout staging",
+            "git pull . FOO",
+            "git push origin HEAD",
+            "git checkout FOO",
+            "git branch -D prototype",
+            "git fetch origin",
+            "git checkout prototype",
+            "git pull . staging",
+            "git push origin HEAD",
+            "git checkout staging",
+            "git checkout FOO"
+          ])
         end
       end
       context 'when target branch != staging || prototype' do

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -41,12 +41,11 @@ describe Socialcast::Gitx::CLI do
     context 'with no existing pull request' do
       before do
         stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
-          .with(:headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'token faketoken', 'Content-Type'=>'application/json', 'User-Agent'=>'socialcast-git-extensions'})
           .to_return(:status => 200, :body => "[]", :headers => {})
       end
       context 'when target branch is omitted' do
         it 'defaults to prototype' do
-          stub_message "#worklog integrating FOO into prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers", :force_post => true
+          stub_message "#worklog integrating FOO into prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
 
           Socialcast::Gitx::CLI.start ['integrate']
 
@@ -68,7 +67,7 @@ describe Socialcast::Gitx::CLI do
         it 'defaults to the custom prototype branch' do
           allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:prototype_branch).and_return('special-prototype')
 
-          stub_message "#worklog integrating FOO into special-prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers", :force_post => true
+          stub_message "#worklog integrating FOO into special-prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
 
           Socialcast::Gitx::CLI.start ['integrate']
 
@@ -88,7 +87,7 @@ describe Socialcast::Gitx::CLI do
       end
       context 'when target branch == prototype' do
         it do
-          stub_message "#worklog integrating FOO into prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers", :force_post => true
+          stub_message "#worklog integrating FOO into prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
 
           Socialcast::Gitx::CLI.start ['integrate', 'prototype']
 
@@ -108,7 +107,7 @@ describe Socialcast::Gitx::CLI do
       end
       context 'when target branch == staging' do
         it do
-          stub_message "#worklog integrating FOO into staging in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers", :force_post => true
+          stub_message "#worklog integrating FOO into staging in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
 
           Socialcast::Gitx::CLI.start ['integrate', 'staging']
 
@@ -146,12 +145,11 @@ describe Socialcast::Gitx::CLI do
           .to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]))
       end
       it 'comments on the PR and does not force a post' do
-        stub_message "#worklog integrating FOO into prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers", :force_post => false
+        stub_message "#worklog integrating FOO into prototype in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
 
         stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
-          .with(
-            :body => "{\"body\":\"Integrated into prototype\"}",
-          ).to_return(:status => 200, :body => "{}", :headers => {})
+          .with(:body => "{\"body\":\"Integrated into prototype\"}")
+          .to_return(:status => 200, :body => "{}", :headers => {})
 
           Socialcast::Gitx::CLI.start ['integrate']
 
@@ -883,28 +881,21 @@ describe Socialcast::Gitx::CLI do
         }
       ]
 
-      stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls/59").
-        with(:headers => { 'Accept' => 'application/json', 'Accept-Encoding' => 'gzip, deflate', 'Authorization' => /token\s\w+/, 'Content-Type' => 'application/json', 'User-Agent' => 'socialcast-git-extensions' }).
-        to_return(:status => 200, :body => pr_response.to_json, :headers => {})
-      stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls/59/commits").
-        with(:headers => { 'Accept' => 'application/json', 'Accept-Encoding' => 'gzip, deflate', 'Authorization' => /token\s\w+/, 'Content-Type' => 'application/json', 'User-Agent' => 'socialcast-git-extensions' }).
-        to_return(:status => 200, :body => commits_response.to_json, :headers => {})
-      stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls").
-         with(:body => "{\"title\":\"backport_59_to_v1.x\",\"base\":\"v1.x\",\"head\":\"backport_59_to_v1.x\",\"body\":\"Backport #59 to https://github.com/socialcast/socialcast-git-extensions/tree/v1.x\\n***\\nsimply testing this out\"}",
-              :headers => { 'Accept' => 'application/json', 'Accept-Encoding' => 'gzip, deflate', 'Authorization' => /token\s\w+/, 'Content-Type' => 'application/json', 'User-Agent'=>'socialcast-git-extensions' }).
-         to_return(:status => 200, :body => '{"html_url": "https://github.com/socialcast/socialcast-git-extensions/pulls/60", "issue_url": "https://api.github.com/repos/repo/project/issues/60"}', :headers => { 'Content-Type' => 'application/json' })
+      stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls/59")
+        .to_return(:status => 200, :body => pr_response.to_json, :headers => {})
+      stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls/59/commits")
+        .to_return(:status => 200, :body => commits_response.to_json, :headers => {})
+      stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls")
+        .with(:body => "{\"title\":\"backport_59_to_v1.x\",\"base\":\"v1.x\",\"head\":\"backport_59_to_v1.x\",\"body\":\"Backport #59 to https://github.com/socialcast/socialcast-git-extensions/tree/v1.x\\n***\\nsimply testing this out\"}")
+        .to_return(:status => 200, :body => '{"html_url": "https://github.com/socialcast/socialcast-git-extensions/pulls/60", "issue_url": "https://api.github.com/repos/repo/project/issues/60"}', :headers => { 'Content-Type' => 'application/json' })
 
       stub_request(:post, "https://api.github.com/repos/repo/project/issues/60/comments")
-        .with(
-          :body => "{\"body\":\"#reviewrequest backport /cc @SocialcastDevelopers #scgitx\"}",
-          :headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'token faketoken', 'Content-Length'=>'68', 'Content-Type'=>'application/json', 'User-Agent'=>'socialcast-git-extensions'}
-        ).to_return(:status => 200, :body => "{}", :headers => {})
+        .with(:body => "{\"body\":\"#reviewrequest backport /cc @SocialcastDevelopers #scgitx\"}")
+        .to_return(:status => 200, :body => "{}", :headers => {})
 
       stub_request(:post, "https://testuser:testpassword@testdomain/api/messages.json")
-        .with(
-          :body => "{\"message\":{\"url\":\"https://github.com/socialcast/socialcast-git-extensions/pulls/60\",\"message_type\":\"review_request\",\"body\":\"#reviewrequest backport #59 to v1.x in socialcast/socialcast-git-extensions #scgitx\\n\\n/cc @SocialcastDevelopers\"}}",
-          :headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'}
-        ).to_return(:status => 200, :body => "", :headers => {})
+        .with(:body => "{\"message\":{\"url\":\"https://github.com/socialcast/socialcast-git-extensions/pulls/60\",\"message_type\":\"review_request\",\"body\":\"#reviewrequest backport #59 to v1.x in socialcast/socialcast-git-extensions #scgitx\\n\\n/cc @SocialcastDevelopers\"}}")
+        .to_return(:status => 200, :body => "", :headers => {})
 
       expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:backportpr).and_call_original
       Socialcast::Gitx::CLI.start ['backportpr', '59', 'v1.x']
@@ -966,9 +957,8 @@ describe Socialcast::Gitx::CLI do
                    }]
       }
 
-      stub_request(:get, "https://api.github.com/search/issues?q=abc123%20type:pr%20repo:socialcast/socialcast-git-extensions").
-        with(:headers => { 'Accept' => 'application/json', 'Accept-Encoding' => 'gzip, deflate', 'Authorization' => /token\s\w+/, 'Content-Type' => 'application/json', 'User-Agent' => 'socialcast-git-extensions'}).
-        to_return(:status => 200, :body => stub_response.to_json, :headers => {})
+      stub_request(:get, "https://api.github.com/search/issues?q=abc123%20type:pr%20repo:socialcast/socialcast-git-extensions")
+        .to_return(:status => 200, :body => stub_response.to_json, :headers => {})
       expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:findpr).and_call_original
       allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:say).with("Searching github pull requests for abc123")
       allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:say).with("\nhttps://github.com/batterseapower/pinyin-toolkit/issues/132\n\tLine Number Indexes Beyond 20 Not Displayed\n\tNick3C 2009-07-12T20:10:41Z")
@@ -984,17 +974,15 @@ describe Socialcast::Gitx::CLI do
       end
       context 'when description != nil' do
         it do
-          stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls").
-            to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
+          stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls")
+            .to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
 
-          stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO").
-            to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
+          stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
+            .to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
 
           stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
-            .with(
-              :body => "{\"body\":\"#reviewrequest \\n/cc @SocialcastDevelopers #scgitx\"}",
-              :headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'token faketoken', 'Content-Length'=>'61', 'Content-Type'=>'application/json', 'User-Agent'=>'socialcast-git-extensions'}
-            ).to_return(:status => 200, :body => "{}", :headers => {})
+            .with(:body => "{\"body\":\"#reviewrequest \\n/cc @SocialcastDevelopers #scgitx\"}")
+            .to_return(:status => 200, :body => "{}", :headers => {})
 
           stub_message "#reviewrequest for FOO in socialcast/socialcast-git-extensions\nPR http://github.com/repo/project/pulls/1 \n\ntesting\n\n/cc @SocialcastDevelopers #scgitx\n\n1 file changed", :message_type => 'review_request'
           allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:changelog_summary).and_return('1 file changed')
@@ -1011,15 +999,13 @@ describe Socialcast::Gitx::CLI do
 
     context 'when review_buddies are specified via a /config YML file' do
       before do
-        stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls").
-          to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
-        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO").
-          to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
+        stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls")
+          .to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
+          .to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
         stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
-          .with(
-            :body => pr_comment_body,
-            :headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'token faketoken', 'Content-Length'=> pr_comment_body.length, 'Content-Type'=>'application/json', 'User-Agent'=>'socialcast-git-extensions'}
-          ).to_return(:status => 200, :body => "{}", :headers => {})
+          .with(:body => pr_comment_body)
+          .to_return(:status => 200, :body => "{}", :headers => {})
 
         stub_request(:patch, "http://github.com/repos/repo/project/issues/1").to_return(:status => 200)
         allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:socialcast_review_buddy).and_return('JaneDoe')
@@ -1068,8 +1054,8 @@ describe Socialcast::Gitx::CLI do
     end
     context 'when description != nil' do
       it do
-        stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls").
-          to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
+        stub_request(:post, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls")
+          .to_return(:status => 200, :body => %q({"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1"}), :headers => {})
 
         Socialcast::Gitx::CLI.start ['createpr', '--description', 'testing']
 
@@ -1088,14 +1074,12 @@ describe Socialcast::Gitx::CLI do
         allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:config_file).and_return(Pathname(''))
       end
       it do
-        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO").
-          to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
+          .to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
 
         stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
-          .with(
-            :body => "{\"body\":\"#reviewrequest \\n/cc @SocialcastDevelopers #scgitx\"}",
-            :headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'token faketoken', 'Content-Length'=>'61', 'Content-Type'=>'application/json', 'User-Agent'=>'socialcast-git-extensions'}
-          ).to_return(:status => 200, :body => "{}", :headers => {})
+          .with(:body => "{\"body\":\"#reviewrequest \\n/cc @SocialcastDevelopers #scgitx\"}")
+          .to_return(:status => 200, :body => "{}", :headers => {})
 
         stub_message "#reviewrequest for FOO in socialcast/socialcast-git-extensions\nPR http://github.com/repo/project/pulls/1 \n\ntesting\n\n/cc @SocialcastDevelopers #scgitx\n\n1 file changed", :message_type => 'review_request'
         allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:changelog_summary).and_return('1 file changed')
@@ -1111,13 +1095,11 @@ describe Socialcast::Gitx::CLI do
 
     context 'when review_buddies are specified via a /config YML file' do
       before do
-        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO").
-          to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
+        stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
+          .to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]), :headers => {})
         stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
-          .with(
-            :body => pr_comment_body,
-            :headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'token faketoken', 'Content-Length'=> pr_comment_body.length, 'Content-Type'=>'application/json', 'User-Agent'=>'socialcast-git-extensions'}
-          ).to_return(:status => 200, :body => "{}", :headers => {})
+          .with(:body => pr_comment_body)
+          .to_return(:status => 200, :body => "{}", :headers => {})
 
         stub_request(:patch, "http://github.com/repos/repo/project/issues/1").to_return(:status => 200)
         allow_any_instance_of(Socialcast::Gitx::CLI).to receive(:socialcast_review_buddy).and_return('JaneDoe')
@@ -1163,10 +1145,9 @@ describe Socialcast::Gitx::CLI do
   describe '#promote' do
     before do
       stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
-        .with(:headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'token faketoken', 'Content-Type'=>'application/json', 'User-Agent'=>'socialcast-git-extensions'})
         .to_return(:status => 200, :body => "[]", :headers => {})
 
-      stub_message "#worklog integrating FOO into staging in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers", :force_post => true
+      stub_message "#worklog integrating FOO into staging in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
       Socialcast::Gitx::CLI.start ['promote']
     end
     it 'should integrate into staging' do

--- a/spec/github_spec.rb
+++ b/spec/github_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe Socialcast::Gitx::Github do
+  let(:test_class) do
+    Class.new do |k|
+      include Socialcast::Gitx::Github
+
+      def say(message); end
+    end
+  end
+  let(:said_messages) { [] }
+  before do
+    stub_const('TestClass', test_class)
+    allow_any_instance_of(TestClass).to receive(:'`') do |_instance, _cmd|
+      raise 'Unstubbed backticks detected'
+    end
+    allow_any_instance_of(TestClass).to receive(:say) do |_instance, message|
+      said_messages << message
+    end
+  end
+  let(:test_instance) { TestClass.new }
+  let(:branch) { 'my-branch' }
+  let(:base_branch) { 'master' }
+  let(:repo) { 'ownername/projectname' }
+
+  describe '#create_pull_request' do
+    subject { test_instance.send(:create_pull_request, branch, repo, body) }
+    let(:create_pr_payload) do
+      {
+        :title => branch,
+        :base => base_branch,
+        :head => branch,
+        :body => body
+      }
+    end
+    let(:dummy_pr_created_response) { { :dummy => :response } }
+    let(:body) { 'This is my pull request.' }
+    before do
+      allow(test_instance).to receive(:base_branch).and_return(base_branch)
+      expect(test_instance).to receive(:github_api_request).with('POST', 'repos/ownername/projectname/pulls', create_pr_payload.to_json).and_return(dummy_pr_created_response)
+    end
+    it { is_expected.to eq dummy_pr_created_response }
+  end
+
+  describe '#pull_requests_for_branch' do
+    subject { test_instance.send(:pull_requests_for_branch, repo, branch) }
+    let(:dummy_pr_list_response) { [{ :dummy => :response }] }
+    before do
+      expect(test_instance).to receive(:github_api_request).with('GET', 'repos/ownername/projectname/pulls?head=ownername:my-branch').and_return(dummy_pr_list_response)
+    end
+    it { is_expected.to eq dummy_pr_list_response }
+  end
+
+  describe '#current_pr_for_branch' do
+    subject(:current_pr) { test_instance.send(:current_pr_for_branch, repo, branch) }
+    let(:dummy_pr_one) { { :dummy => :pr1 } }
+    let(:dummy_pr_two) { { :dummy => :pr2 } }
+    before do
+      expect(test_instance).to receive(:pull_requests_for_branch).with(repo, branch).and_return(dummy_pr_list_response)
+    end
+    context 'when an empty pr list is returned' do
+      let(:dummy_pr_list_response) { [] }
+      it { is_expected.to be_nil }
+    end
+    context 'when a single pr is returned' do
+      let(:dummy_pr_list_response) { [dummy_pr_one] }
+      it { is_expected.to eq dummy_pr_one }
+    end
+    context 'when multiple prs are returned' do
+      let(:dummy_pr_list_response) { [dummy_pr_one, dummy_pr_two] }
+      it { expect { current_pr }.to raise_error 'Multiple (2) open PRs for my-branch found in ownername/projectname, unable to proceed' }
+    end
+  end
+
+  describe '#assign_pull_request' do
+    subject { test_instance.send(:assign_pull_request, assignee, issue_url) }
+    let(:assignee) { 'janedoe' }
+    let(:issue_url) { 'repos/ownername/projectname/issues/1' }
+    let(:dummy_assignment_response) { [{ :dummy => :response }] }
+    let(:assign_payload) { { :assignee => assignee } }
+    before do
+      expect(test_instance).to receive(:github_api_request).with('PATCH', 'repos/ownername/projectname/issues/1', assign_payload.to_json).and_return(dummy_assignment_response)
+    end
+    it { is_expected.to eq dummy_assignment_response }
+  end
+
+  describe '#comment_on_issue' do
+    subject { test_instance.send(:comment_on_issue, issue_url, comment_body) }
+    let(:issue_url) { 'repos/ownername/projectname/issues/1' }
+    let(:dummy_comment_response) { { :dummy => :response } }
+    let(:comment_payload) { { :body => comment_body } }
+    let(:comment_body) { 'Integrating into staging' }
+    before do
+      expect(test_instance).to receive(:github_api_request).with('POST', 'repos/ownername/projectname/issues/1/comments', comment_payload.to_json).and_return(dummy_comment_response)
+    end
+    it { is_expected.to eq dummy_comment_response }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'bundler/setup'
 require 'rspec/mocks'
 require 'webmock/rspec'
 require 'pry'
-
+require 'byebug'
 require 'socialcast-git-extensions/cli'
 
 ENV['SCGITX_TEST'] = 'true'


### PR DESCRIPTION
Allow for better interplay between this gem and the [socialcast github webhook integration](http://blog.socialcast.com/socialcast-integration-store-release/) by 
- Adding a config option for `share_via_pr_comments`, which changes the behavior of reviewrequest and branch-integration messages to be github issue/PR comments instead of independent socialcast message posts
- Add independent `createpr` and `assignpr` operations to facilitate creating PRs earlier in the development flow
- Related spec cleanup and tightening-up
