### PR TITLE
label-trumps-comment

### DIFF
--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -238,8 +238,7 @@ module Socialcast
         say("WARNING: Unable to find current pull request.  Use `git createpr` to create one.", :red) unless current_pr
 
         if use_pr_comments? && current_pr
-          issue_message = "Integrated into #{target_branch}"
-          comment_on_issue(current_pr['issue_url'], issue_message) unless options[:quiet]
+          add_label_to_issue(current_pr['issue_url'], target_branch)
         else
           message = <<-EOS.strip_heredoc
             #worklog integrating #{branch} into #{target_branch} in #{current_repo} #scgitx

--- a/lib/socialcast-git-extensions/github.rb
+++ b/lib/socialcast-git-extensions/github.rb
@@ -78,6 +78,12 @@ module Socialcast
         github_api_request 'POST', "#{issue_url}/comments", { :body => comment_body }.to_json
       end
 
+      # add a label to an issue
+      # https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
+      def add_label_to_issue(issue_url, label_name)
+        github_api_request 'POST', "#{issue_url}/labels", [ label_name ].to_json
+      end
+
       # @returns [String] socialcast username to assign the review to
       # @returns [nil] when no buddy system configured or user not found
       def socialcast_review_buddy(current_user)

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "4.0"
+    VERSION = "4.1"
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -153,9 +153,9 @@ describe Socialcast::Gitx::CLI do
         stub_request(:get, "https://api.github.com/repos/socialcast/socialcast-git-extensions/pulls?head=socialcast:FOO")
           .to_return(:status => 200, :body => %q([{"html_url": "http://github.com/repo/project/pulls/1", "issue_url": "http://api.github.com/repos/repo/project/issues/1", "body":"testing"}]))
       end
-      let!(:github_api_comments_create) do
-        stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/comments")
-          .with(:body => "{\"body\":\"Integrated into prototype\"}")
+      let!(:github_api_label_add) do
+        stub_request(:post, "http://api.github.com/repos/repo/project/issues/1/labels")
+          .with(:body => "[\"prototype\"]")
           .to_return(:status => 200, :body => "{}", :headers => {})
       end
       before do
@@ -180,7 +180,7 @@ describe Socialcast::Gitx::CLI do
             "git checkout FOO"
           ])
           expect(github_api_pulls_list).to have_been_requested
-          expect(github_api_comments_create).to_not have_been_requested
+          expect(github_api_label_add).to_not have_been_requested
         end
       end
       context 'when use_pr_comments? is true' do
@@ -201,7 +201,7 @@ describe Socialcast::Gitx::CLI do
             "git checkout FOO"
           ])
           expect(github_api_pulls_list).to have_been_requested
-          expect(github_api_comments_create).to have_been_requested
+          expect(github_api_label_add).to have_been_requested
         end
       end
     end


### PR DESCRIPTION
When running `git integrate`, assign the branch name as a label on the PR instead of adding an “Integrated into staging” comment.  This will keep the noise down on the PR comment area and the Socialcast PR message thread, as well as any possible email notifications that could be generated by those comments.