### PR TITLE
restore-promote

### DIFF
--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -250,9 +250,8 @@ module Socialcast
         end
       end
 
-      desc 'promote', '(DEPRECATED) promote the current branch into staging'
+      desc 'promote', 'integrate the current branch into staging'
       def promote
-        say "DEPRECATED: Use `git integrate #{staging_branch}` instead", :red
         integrate staging_branch
       end
 


### PR DESCRIPTION
The `git promote` command isn't really deprecated, so get rid of the comment and warning that says so.