### PR TITLE
update-prototype-on-release-when-staging-not-enforced

### DIFF
--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -311,7 +311,7 @@ module Socialcast
         run_cmd "git pull . #{branch}"
         run_cmd "git push origin HEAD"
         integrate_branch(base_branch, staging_branch)
-        integrate_branch(base_branch, prototype_branch) unless enforce_staging_before_release?
+        integrate_branch(base_branch, prototype_branch)
         cleanup
 
         unless use_pr_comments?

--- a/lib/socialcast-git-extensions/cli.rb
+++ b/lib/socialcast-git-extensions/cli.rb
@@ -311,6 +311,7 @@ module Socialcast
         run_cmd "git pull . #{branch}"
         run_cmd "git push origin HEAD"
         integrate_branch(base_branch, staging_branch)
+        integrate_branch(base_branch, prototype_branch) unless enforce_staging_before_release?
         cleanup
 
         unless use_pr_comments?

--- a/lib/socialcast-git-extensions/version.rb
+++ b/lib/socialcast-git-extensions/version.rb
@@ -1,5 +1,5 @@
 module Socialcast
   module Gitx
-    VERSION = "4.0"
+    VERSION = "4.0.1"
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -247,6 +247,12 @@ describe Socialcast::Gitx::CLI do
             "git checkout staging",
             "git pull . master",
             "git push origin HEAD",
+            "git checkout master",
+            "git branch -D prototype",
+            "git fetch origin",
+            "git checkout prototype",
+            "git pull . master",
+            "git push origin HEAD",
             "git checkout master"
           ])
         end
@@ -284,7 +290,7 @@ describe Socialcast::Gitx::CLI do
         let(:branches_in_last_known_good_staging) { ['another-branch'] }
         before do
           expect_message "#worklog releasing FOO to master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
-          expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:enforce_staging_before_release?).twice.and_return(false)
+          expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:enforce_staging_before_release?).and_return(false)
           expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:yes?).and_return(true)
           expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:cleanup)
           Socialcast::Gitx::CLI.start ['release']
@@ -357,6 +363,12 @@ describe Socialcast::Gitx::CLI do
           "git checkout staging",
           "git pull . special-master",
           "git push origin HEAD",
+          "git checkout special-master",
+          "git branch -D prototype",
+          "git fetch origin",
+          "git checkout prototype",
+          "git pull . special-master",
+          "git push origin HEAD",
           "git checkout special-master"
         ])
       end
@@ -393,6 +405,12 @@ describe Socialcast::Gitx::CLI do
           "git branch -D staging",
           "git fetch origin",
           "git checkout staging",
+          "git pull . special-master",
+          "git push origin HEAD",
+          "git checkout special-master",
+          "git branch -D prototype",
+          "git fetch origin",
+          "git checkout prototype",
           "git pull . special-master",
           "git push origin HEAD",
           "git checkout special-master"
@@ -432,6 +450,12 @@ describe Socialcast::Gitx::CLI do
           "git branch -D staging",
           "git fetch origin",
           "git checkout staging",
+          "git pull . special-master",
+          "git push origin HEAD",
+          "git checkout special-master",
+          "git branch -D prototype",
+          "git fetch origin",
+          "git checkout prototype",
           "git pull . special-master",
           "git push origin HEAD",
           "git checkout special-master"

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -284,7 +284,7 @@ describe Socialcast::Gitx::CLI do
         let(:branches_in_last_known_good_staging) { ['another-branch'] }
         before do
           expect_message "#worklog releasing FOO to master in socialcast/socialcast-git-extensions #scgitx\n/cc @SocialcastDevelopers"
-          expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:enforce_staging_before_release?).and_return(false)
+          expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:enforce_staging_before_release?).twice.and_return(false)
           expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:yes?).and_return(true)
           expect_any_instance_of(Socialcast::Gitx::CLI).to receive(:cleanup)
           Socialcast::Gitx::CLI.start ['release']
@@ -301,6 +301,12 @@ describe Socialcast::Gitx::CLI do
             "git branch -D staging",
             "git fetch origin",
             "git checkout staging",
+            "git pull . master",
+            "git push origin HEAD",
+            "git checkout master",
+            "git branch -D prototype",
+            "git fetch origin",
+            "git checkout prototype",
             "git pull . master",
             "git push origin HEAD",
             "git checkout master"


### PR DESCRIPTION
Modify `git-release` behavior to update prototype when `enforce_staging_before_release` is false

When `enforce_staging_before_release` is true, prototype will already have the latest changes since `git-promote` pushes changes to both staging and prototype. This guarentee doesn't apply when `enforce_staging_before_release` is false, so add the `integrate_branch` step to ensure branches are kept up to date.