### PR TITLE
fix-path-include-http-check

### DIFF
--- a/lib/socialcast-git-extensions/github.rb
+++ b/lib/socialcast-git-extensions/github.rb
@@ -121,7 +121,12 @@ module Socialcast
       end
 
       def github_api_request(method, path, payload = nil)
-        url = path.include?('http') ? path : "https://api.github.com/#{path}"
+        url = if path.start_with?('http://') || path.start_with?('https://')
+          path
+        else
+          "https://api.github.com/#{path}"
+        end
+
         JSON.parse RestClient::Request.new(:url => url, :method => method, :payload => payload, :headers => { :accept => :json, :content_type => :json, 'Authorization' => "token #{authorization_token}", :user_agent => 'socialcast-git-extensions' }).execute
       rescue RestClient::Exception => e
         process_error e

--- a/spec/github_spec.rb
+++ b/spec/github_spec.rb
@@ -47,6 +47,7 @@ describe Socialcast::Gitx::Github do
     let(:branch) { 'my-http-and-https-branch' }
     let(:dummy_pr_list_response) { [{ 'dummy' => 'response' }] }
     before do
+      allow(test_instance).to receive(:authorization_token).and_return('abc123')
       expect_any_instance_of(RestClient::Request).to receive(:execute) do |instance|
         expect(instance.url).to eq 'https://api.github.com/repos/ownername/projectname/pulls?head=ownername:my-http-and-https-branch'
         '[{ "dummy": "response" }]'

--- a/spec/github_spec.rb
+++ b/spec/github_spec.rb
@@ -33,7 +33,7 @@ describe Socialcast::Gitx::Github do
         :body => body
       }
     end
-    let(:dummy_pr_created_response) { { :dummy => :response } }
+    let(:dummy_pr_created_response) { { 'dummy' => 'response' } }
     let(:body) { 'This is my pull request.' }
     before do
       allow(test_instance).to receive(:base_branch).and_return(base_branch)
@@ -44,9 +44,13 @@ describe Socialcast::Gitx::Github do
 
   describe '#pull_requests_for_branch' do
     subject { test_instance.send(:pull_requests_for_branch, repo, branch) }
-    let(:dummy_pr_list_response) { [{ :dummy => :response }] }
+    let(:branch) { 'my-http-and-https-branch' }
+    let(:dummy_pr_list_response) { [{ 'dummy' => 'response' }] }
     before do
-      expect(test_instance).to receive(:github_api_request).with('GET', 'repos/ownername/projectname/pulls?head=ownername:my-branch').and_return(dummy_pr_list_response)
+      expect_any_instance_of(RestClient::Request).to receive(:execute) do |instance|
+        expect(instance.url).to eq 'https://api.github.com/repos/ownername/projectname/pulls?head=ownername:my-http-and-https-branch'
+        '[{ "dummy": "response" }]'
+      end
     end
     it { is_expected.to eq dummy_pr_list_response }
   end


### PR DESCRIPTION
Fix the check for a scheme in github_api_response, which would break if the string `http` occurred anywhere within the string.