### PR TITLE
Remove .ruby-version

### DIFF
--- a/.ruby-version
+++ b/.ruby-version
@@ -1,1 +1,0 @@
-default


### PR DESCRIPTION
Remove .ruby-version as the "default" keyword is not supported in rbenv and Ruby version managers will load the default Ruby version automatically.

```
$ bundle install
rbenv: version `default' is not installed (set by /Users/brianjohn/projects/socialcast-git-extensions/.ruby-version)
```