### PR TITLE
update-readme-and-ask-for-token-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Where "(your domain)" would be the fully qualified domain name of the Socialcast
 Some of the extentions provided make use of the GitHub Application Token. When using commands such as [`git findpr`](https://github.com/socialcast/socialcast-git-extensions#git-findpr-) or [`git reviewrequest`](https://github.com/socialcast/socialcast-git-extensions#git-reviewrequest) the extensions will accept the credentials of the GitHub account and then install the GitHub token for you. If the GitHub account has two-factor authentication enabled then a manual installation of the GitHub Token is required.
 
 #### Manual GitHub Token Installation
-Access the [Application settings](https://github.com/settings/applications) of your github.com account and select "*Generate new token*" or use an existing Github Application token. Store the token in  `~/.socialcast/credentials.yml`. Example:
+Access the [Application settings](https://github.com/settings/tokens) of your github.com account and select "*Generate new token*" or use an existing Github Application token. Store the token in  `~/.socialcast/credentials.yml`. Example:
 ```yaml
 ---
 :domain: er.staging.socialcast.com

--- a/lib/socialcast-git-extensions/github.rb
+++ b/lib/socialcast-git-extensions/github.rb
@@ -20,6 +20,7 @@ module Socialcast
         raise "Github user not configured.  Run: `git config --global github.user 'me@email.com'`" if username.empty?
         password = HighLine.new.ask("Github password for #{username}: ") { |q| q.echo = false }
         token_name = HighLine.new.ask('Github token name for this machine')
+        token_name = 'Socialcast Git eXtension' if token_name.empty?
 
         payload = {:scopes => ['repo'], :note => token_name, :note_url => 'https://github.com/socialcast/socialcast-git-extensions'}.to_json
         response = RestClient::Request.new(:url => "https://api.github.com/authorizations", :method => "POST", :user => username, :password => password, :payload => payload, :headers => {:accept => :json, :content_type => :json, :user_agent => 'socialcast-git-extensions'}).execute

--- a/lib/socialcast-git-extensions/github.rb
+++ b/lib/socialcast-git-extensions/github.rb
@@ -19,8 +19,9 @@ module Socialcast
         username = current_user
         raise "Github user not configured.  Run: `git config --global github.user 'me@email.com'`" if username.empty?
         password = HighLine.new.ask("Github password for #{username}: ") { |q| q.echo = false }
-        token_name = HighLine.new.ask('Github token name for this machine')
-        token_name = 'Socialcast Git eXtension' if token_name.empty?
+        default_token_name = 'Socialcast Git eXtension'
+        token_name = HighLine.new.ask("Github token name for this machine (default: '#{default_token_name}'):")
+        token_name = default_token_name if token_name.empty?
 
         payload = {:scopes => ['repo'], :note => token_name, :note_url => 'https://github.com/socialcast/socialcast-git-extensions'}.to_json
         response = RestClient::Request.new(:url => "https://api.github.com/authorizations", :method => "POST", :user => username, :password => password, :payload => payload, :headers => {:accept => :json, :content_type => :json, :user_agent => 'socialcast-git-extensions'}).execute

--- a/lib/socialcast-git-extensions/github.rb
+++ b/lib/socialcast-git-extensions/github.rb
@@ -19,8 +19,9 @@ module Socialcast
         username = current_user
         raise "Github user not configured.  Run: `git config --global github.user 'me@email.com'`" if username.empty?
         password = HighLine.new.ask("Github password for #{username}: ") { |q| q.echo = false }
+        token_name = HighLine.new.ask('Github token name for this machine')
 
-        payload = {:scopes => ['repo'], :note => 'Socialcast Git eXtension', :note_url => 'https://github.com/socialcast/socialcast-git-extensions'}.to_json
+        payload = {:scopes => ['repo'], :note => token_name, :note_url => 'https://github.com/socialcast/socialcast-git-extensions'}.to_json
         response = RestClient::Request.new(:url => "https://api.github.com/authorizations", :method => "POST", :user => username, :password => password, :payload => payload, :headers => {:accept => :json, :content_type => :json, :user_agent => 'socialcast-git-extensions'}).execute
         data = JSON.parse response.body
         token = data['token']


### PR DESCRIPTION
- Update the readme to point to the correct github page where user can update their tokens
- Add a way for users to enter the name of the token instead of the hardcoded value `Socialcast Git eXtension`. This will prevent future installations to go through. Github requires [tokens to be named uniquely](https://github.com/boxen/boxen/issues/182#issuecomment-97595422)